### PR TITLE
feat(coach): delayed user type choice

### DIFF
--- a/schema.prisma
+++ b/schema.prisma
@@ -116,7 +116,7 @@ model User {
   lastname      String
   email         String?    @unique
   password      String?
-  type          UserType
+  type          UserType?
   permissions   String?
   registerToken String?    @unique
   resetToken    String?    @unique

--- a/src/controllers/admin/users/replace.ts
+++ b/src/controllers/admin/users/replace.ts
@@ -56,7 +56,7 @@ export default [
         return forbidden(response, Error.NotPaid);
       }
 
-      await replaceUser(user, targetUser, team, user.type);
+      await replaceUser(user, targetUser, team);
 
       const updatedUser = await fetchUser(request.params.userId);
       const updatedTargetUser = await fetchUser(request.body.replacingUserId);

--- a/src/controllers/admin/users/replace.ts
+++ b/src/controllers/admin/users/replace.ts
@@ -56,7 +56,7 @@ export default [
         return forbidden(response, Error.NotPaid);
       }
 
-      await replaceUser(user, targetUser, team);
+      await replaceUser(user, targetUser, team, user.type);
 
       const updatedUser = await fetchUser(request.params.userId);
       const updatedTargetUser = await fetchUser(request.body.replacingUserId);

--- a/src/controllers/auth/openapi.yml
+++ b/src/controllers/auth/openapi.yml
@@ -69,9 +69,6 @@
               password:
                 type: string
                 minLength: 6
-              type:
-                type: string
-                enum: [player, coach]
               discordId:
                 type: string
     responses:

--- a/src/controllers/auth/register.ts
+++ b/src/controllers/auth/register.ts
@@ -1,4 +1,3 @@
-import { UserType } from '@prisma/client';
 import { NextFunction, Request, Response } from 'express';
 import Joi from 'joi';
 import { isNotAuthenticated } from '../../middlewares/authentication';
@@ -18,17 +17,16 @@ export default [
       lastname: validators.lastname.required(),
       email: validators.email.required(),
       password: validators.password.required(),
-      type: Joi.string().valid(UserType.player, UserType.coach).required(),
     }),
   ),
 
   // Controller
   async (request: Request, response: Response, next: NextFunction) => {
-    const { username, firstname, lastname, email, password, type } = request.body;
+    const { username, firstname, lastname, email, password } = request.body;
 
     // Tries to create a user
     try {
-      await createUser(username, firstname, lastname, email, password, type);
+      await createUser(username, firstname, lastname, email, password);
     } catch (error) {
       // If the email already exists in the database, throw a bad request
       if (error.code === 'P2002' && error.meta && error.meta.target === 'email_unique')

--- a/src/controllers/openapi.yml
+++ b/src/controllers/openapi.yml
@@ -97,6 +97,7 @@ components:
           type: string
         type:
           $ref: '#/components/schemas/Type'
+          nullable: true
         hasPaid:
           type: boolean
 

--- a/src/controllers/teams/createTeam.ts
+++ b/src/controllers/teams/createTeam.ts
@@ -1,3 +1,4 @@
+import { UserType } from '@prisma/client';
 import { NextFunction, Request, Response } from 'express';
 import Joi from 'joi';
 import { isNotInATeam } from '../../middlewares/team';
@@ -16,13 +17,14 @@ export default [
     Joi.object({
       name: validators.teamName.required(),
       tournamentId: validators.tournamentId.required(),
+      captainType: Joi.string().valid(UserType.player, UserType.coach).required(),
     }),
   ),
 
   // Controller
   async (request: Request, response: Response, next: NextFunction) => {
     try {
-      const { name, tournamentId } = request.body;
+      const { name, tournamentId, captainType } = request.body;
 
       const tournament = await fetchTournament(tournamentId);
 
@@ -32,7 +34,7 @@ export default [
       }
 
       try {
-        const team = await createTeam(name, tournamentId, response.locals.user.id);
+        const team = await createTeam(name, tournamentId, response.locals.user.id, captainType);
         return created(response, filterTeam(team));
       } catch (error) {
         // If the email already exists in the database, throw a bad request

--- a/src/controllers/teams/createTeam.ts
+++ b/src/controllers/teams/createTeam.ts
@@ -17,14 +17,14 @@ export default [
     Joi.object({
       name: validators.teamName.required(),
       tournamentId: validators.tournamentId.required(),
-      captainType: Joi.string().valid(UserType.player, UserType.coach).required(),
+      userType: Joi.string().valid(UserType.player, UserType.coach).required(),
     }),
   ),
 
   // Controller
   async (request: Request, response: Response, next: NextFunction) => {
     try {
-      const { name, tournamentId, captainType } = request.body;
+      const { name, tournamentId, userType } = request.body;
 
       const tournament = await fetchTournament(tournamentId);
 
@@ -34,7 +34,7 @@ export default [
       }
 
       try {
-        const team = await createTeam(name, tournamentId, response.locals.user.id, captainType);
+        const team = await createTeam(name, tournamentId, response.locals.user.id, userType);
         return created(response, filterTeam(team));
       } catch (error) {
         // If the email already exists in the database, throw a bad request

--- a/src/controllers/teams/openapi.yml
+++ b/src/controllers/teams/openapi.yml
@@ -69,8 +69,8 @@
               tournamentId:
                 description: Identifiant du tournoi
                 type: integer
-              captainType:
-                description: Le type d'utilisateur du capitaine d'équipe
+              userType:
+                description: Type d'utilisateur
                 type: string
                 enum: [player, coach]
     responses:
@@ -204,13 +204,17 @@
         schema:
           type: string
         required: true
-      - in: query
-        name: userType
-        description: Type d'utilisateur
-        schema:
-          type: string
-          enum: [player, coach]
-        required: true
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              userType:
+                description: Type d'utilisateur
+                type: string
+                enum: [player, coach]
     responses:
       200:
         description: La demande a bien été envoyée. Les informations de l'utilisateur sont renvoyées.

--- a/src/controllers/teams/openapi.yml
+++ b/src/controllers/teams/openapi.yml
@@ -48,7 +48,6 @@
               $ref: '#/components/schemas/Error'
             example:
               error: Aucun tournoi n'est associé à cet identifiant
-
   post:
     summary: Crée une équipe
     description: Crée une équipe.<br/>
@@ -70,6 +69,10 @@
               tournamentId:
                 description: Identifiant du tournoi
                 type: integer
+              captainType:
+                description: Le type d'utilisateur du capitaine d'équipe
+                type: string
+                enum: [player, coach]
     responses:
       201:
         description: L'équipe a bien été créée. Ses informations sont retournées.
@@ -200,6 +203,13 @@
         description: Identifiant de l'équipe cible
         schema:
           type: string
+        required: true
+      - in: query
+        name: userType
+        description: Type d'utilisateur
+        schema:
+          type: string
+          enum: [player, coach]
         required: true
     responses:
       200:

--- a/src/operations/user.ts
+++ b/src/operations/user.ts
@@ -84,7 +84,7 @@ export const createUser = async (
   lastname: string,
   email: string,
   password: string,
-  type: UserType,
+  type?: UserType,
 ) => {
   const salt = await userOperations.genSalt(env.bcrypt.rounds);
   const hashedPassword = await userOperations.hash(password, salt);

--- a/tests/admin/users/replace.test.ts
+++ b/tests/admin/users/replace.test.ts
@@ -138,9 +138,11 @@ describe('POST /admin/users/:userId/replace', () => {
 
     expect(body.replacedUser.id).to.be.equal(user.id);
     expect(body.replacedUser.teamId).to.be.null;
+    expect(body.replacedUser.type).to.be.null;
 
     expect(body.replacingUser.id).to.be.equal(targetUser.id);
     expect(body.replacingUser.teamId).to.be.equal(team.id);
+    expect(body.replacingUser.type).to.be.equal(user.type);
 
     expect(updatedTeam.captainId).to.be.equal(body.replacingUser.id);
   });

--- a/tests/teams/acceptRequest.test.ts
+++ b/tests/teams/acceptRequest.test.ts
@@ -20,7 +20,7 @@ describe('POST /teams/current/join-requests/:userId', () => {
   before(async () => {
     team = await createFakeTeam({ members: 2 });
     user = await createFakeUser();
-    await teamOperations.askJoinTeam(team.id, user.id);
+    await teamOperations.askJoinTeam(team.id, user.id, UserType.player);
 
     captain = getCaptain(team);
     token = generateToken(captain);
@@ -99,7 +99,7 @@ describe('POST /teams/current/join-requests/:userId', () => {
 
     const fullCaptain = getCaptain(fullTeam);
     const fullToken = generateToken(fullCaptain);
-    await teamOperations.askJoinTeam(fullTeam.id, otherUser.id);
+    await teamOperations.askJoinTeam(fullTeam.id, otherUser.id, UserType.player);
 
     await request(app)
       .post(`/teams/current/join-requests/${otherUser.id}`)
@@ -109,11 +109,11 @@ describe('POST /teams/current/join-requests/:userId', () => {
 
   it('should succeed to join a full team as a coach', async () => {
     const fullTeam = await createFakeTeam({ members: 5 });
-    const otherUser = await createFakeUser({ type: UserType.coach });
+    const otherUser = await createFakeUser();
 
     const fullCaptain = getCaptain(fullTeam);
     const fullToken = generateToken(fullCaptain);
-    await teamOperations.askJoinTeam(fullTeam.id, otherUser.id);
+    await teamOperations.askJoinTeam(fullTeam.id, otherUser.id, UserType.coach);
 
     await request(app)
       .post(`/teams/current/join-requests/${otherUser.id}`)

--- a/tests/teams/cancelTeamRequest.test.ts
+++ b/tests/teams/cancelTeamRequest.test.ts
@@ -8,6 +8,7 @@ import { Error, Team, User } from '../../src/types';
 import { createFakeUser, createFakeTeam } from '../utils';
 import { generateToken } from '../../src/utils/users';
 import { fetchUser } from '../../src/operations/user';
+import { UserType } from '.prisma/client';
 
 describe('DELETE /teams/current/join-requests/current', () => {
   let user: User;
@@ -17,7 +18,7 @@ describe('DELETE /teams/current/join-requests/current', () => {
   before(async () => {
     team = await createFakeTeam({ members: 2 });
     user = await createFakeUser();
-    await teamOperations.askJoinTeam(team.id, user.id);
+    await teamOperations.askJoinTeam(team.id, user.id, UserType.player);
     token = generateToken(user);
   });
 
@@ -48,6 +49,7 @@ describe('DELETE /teams/current/join-requests/current', () => {
     const deletedRequestUser = await fetchUser(user.id);
 
     expect(deletedRequestUser.askingTeamId).to.be.null;
+    expect(deletedRequestUser.type).to.be.null;
   });
 
   it('should fail as the user has removed the request', async () => {

--- a/tests/teams/createTeam.test.ts
+++ b/tests/teams/createTeam.test.ts
@@ -20,7 +20,7 @@ describe('POST /teams', () => {
   const teamBody = {
     name: 'ZeBest',
     tournamentId: 'lol',
-    captainType: UserType.player,
+    userType: UserType.player,
   };
 
   before(async () => {
@@ -95,7 +95,7 @@ describe('POST /teams', () => {
       .post('/teams')
       .send({
         ...teamBody,
-        captainType: UserType.player,
+        userType: UserType.player,
       })
       .set('Authorization', `Bearer ${token}`)
       .expect(201);
@@ -115,7 +115,7 @@ describe('POST /teams', () => {
       .send({
         ...teamBody,
         name: 'GeoCoaching',
-        captainType: UserType.coach,
+        userType: UserType.coach,
       })
       .set('Authorization', `Bearer ${newToken}`)
       .expect(201);
@@ -151,7 +151,7 @@ describe('POST /teams', () => {
     expect(body.tournamentId).to.be.equal('csgo');
     expect(body.captainId).to.be.equal(newUser.id);
     const remoteUser = await userOperations.fetchUser(body.captainId);
-    expect(remoteUser.type).to.be.equal(teamBody.captainType);
+    expect(remoteUser.type).to.be.equal(teamBody.userType);
 
     // Check if the object was filtered
     expect(body.updatedAt).to.be.undefined;
@@ -174,12 +174,12 @@ describe('POST /teams', () => {
 
     await request(app)
       .post('/teams')
-      .send({ name: 'otherName', tournamentId: teamBody.tournamentId, captainType: teamBody.captainType })
+      .send({ name: 'otherName', tournamentId: teamBody.tournamentId, userType: teamBody.userType })
       .set('Authorization', `Bearer ${otherToken}`)
       .expect(410, { error: Error.TournamentFull });
   });
 
-  it('shall deny orga captain type', async () => {
+  it('should deny orga captain type', async () => {
     const newUser = await createFakeUser();
     const newToken = generateToken(newUser);
 
@@ -187,13 +187,13 @@ describe('POST /teams', () => {
       .post('/teams')
       .send({
         ...teamBody,
-        captainType: UserType.orga,
+        userType: UserType.orga,
       })
       .set('Authorization', `Bearer ${newToken}`)
       .expect(400, { error: Error.InvalidBody });
   });
 
-  it("shall error if captain hasn't chosen a type", async () => {
+  it("should fail if captain hasn't chosen a type", async () => {
     const newUser = await createFakeUser();
     const newToken = generateToken(newUser);
 

--- a/tests/teams/createTeam.test.ts
+++ b/tests/teams/createTeam.test.ts
@@ -4,10 +4,12 @@ import app from '../../src/app';
 import { sandbox } from '../setup';
 import * as teamOperations from '../../src/operations/team';
 import * as tournamentOperations from '../../src/operations/tournament';
+import * as userOperations from '../../src/operations/user';
 import database from '../../src/services/database';
 import { Error, User } from '../../src/types';
 import { createFakeUser, createFakeTeam } from '../utils';
 import { generateToken } from '../../src/utils/users';
+import { UserType } from '.prisma/client';
 
 describe('POST /teams', () => {
   let user: User;
@@ -18,6 +20,7 @@ describe('POST /teams', () => {
   const teamBody = {
     name: 'ZeBest',
     tournamentId: 'lol',
+    captainType: UserType.player,
   };
 
   before(async () => {
@@ -64,7 +67,7 @@ describe('POST /teams', () => {
   it("should fail because the tournament doesn't exists", async () => {
     await request(app)
       .post('/teams')
-      .send({ name: teamBody.name, tournamentId: 'factorio' })
+      .send({ ...teamBody, tournamentId: 'factorio' })
       .set('Authorization', `Bearer ${token}`)
       .expect(400, { error: Error.InvalidBody });
   });
@@ -87,16 +90,40 @@ describe('POST /teams', () => {
       .expect(500, { error: Error.InternalServerError });
   });
 
-  it('should succesfully create a team', async () => {
+  it('should successfully create a team (as a player)', async () => {
     const response = await request(app)
       .post('/teams')
-      .send(teamBody)
+      .send({
+        ...teamBody,
+        captainType: UserType.player,
+      })
       .set('Authorization', `Bearer ${token}`)
       .expect(201);
-
     expect(response.body.name).to.be.equal(teamBody.name);
     expect(response.body.tournamentId).to.be.equal(teamBody.tournamentId);
     expect(response.body.captainId).to.be.equal(user.id);
+    const remoteUser = await userOperations.fetchUser(response.body.captainId);
+    expect(remoteUser.type).to.be.equal(UserType.player);
+  });
+
+  it('should successfully create a team (as a coach)', async () => {
+    const newUser = await createFakeUser();
+    const newToken = generateToken(newUser);
+
+    const response = await request(app)
+      .post('/teams')
+      .send({
+        ...teamBody,
+        name: 'GeoCoaching',
+        captainType: UserType.coach,
+      })
+      .set('Authorization', `Bearer ${newToken}`)
+      .expect(201);
+    expect(response.body.name).to.be.equal('GeoCoaching');
+    expect(response.body.tournamentId).to.be.equal(teamBody.tournamentId);
+    expect(response.body.captainId).to.be.equal(newUser.id);
+    const remoteUser = await userOperations.fetchUser(response.body.captainId);
+    expect(remoteUser.type).to.be.equal(UserType.coach);
   });
 
   it('fail to create a team as it already exists in the tournament', async () => {
@@ -116,13 +143,15 @@ describe('POST /teams', () => {
 
     const { body } = await request(app)
       .post('/teams')
-      .send({ name: teamBody.name, tournamentId: 'csgo' })
+      .send({ ...teamBody, tournamentId: 'csgo' })
       .set('Authorization', `Bearer ${newToken}`)
       .expect(201);
 
     expect(body.name).to.be.equal(teamBody.name);
     expect(body.tournamentId).to.be.equal('csgo');
     expect(body.captainId).to.be.equal(newUser.id);
+    const remoteUser = await userOperations.fetchUser(body.captainId);
+    expect(remoteUser.type).to.be.equal(teamBody.captainType);
 
     // Check if the object was filtered
     expect(body.updatedAt).to.be.undefined;
@@ -145,8 +174,36 @@ describe('POST /teams', () => {
 
     await request(app)
       .post('/teams')
-      .send({ name: 'otherName', tournamentId: teamBody.tournamentId })
+      .send({ name: 'otherName', tournamentId: teamBody.tournamentId, captainType: teamBody.captainType })
       .set('Authorization', `Bearer ${otherToken}`)
       .expect(410, { error: Error.TournamentFull });
+  });
+
+  it('shall deny orga captain type', async () => {
+    const newUser = await createFakeUser();
+    const newToken = generateToken(newUser);
+
+    await request(app)
+      .post('/teams')
+      .send({
+        ...teamBody,
+        captainType: UserType.orga,
+      })
+      .set('Authorization', `Bearer ${newToken}`)
+      .expect(400, { error: Error.InvalidBody });
+  });
+
+  it("shall error if captain hasn't chosen a type", async () => {
+    const newUser = await createFakeUser();
+    const newToken = generateToken(newUser);
+
+    await request(app)
+      .post('/teams')
+      .send({
+        name: teamBody.name,
+        tournamentId: teamBody.tournamentId,
+      })
+      .set('Authorization', `Bearer ${newToken}`)
+      .expect(400, { error: Error.InvalidBody });
   });
 });

--- a/tests/teams/createTeamRequest.test.ts
+++ b/tests/teams/createTeamRequest.test.ts
@@ -7,6 +7,7 @@ import database from '../../src/services/database';
 import { Error, Team, User } from '../../src/types';
 import { createFakeUser, createFakeTeam } from '../utils';
 import { generateToken } from '../../src/utils/users';
+import { UserType } from '.prisma/client';
 
 describe('POST /teams/:teamId/join-requests', () => {
   let user: User;
@@ -28,12 +29,16 @@ describe('POST /teams/:teamId/join-requests', () => {
   it('should fail because the team does not exists', async () => {
     await request(app)
       .post(`/teams/1A2B3C/join-requests`)
+      .send({ userType: UserType.player })
       .set('Authorization', `Bearer ${token}`)
       .expect(404, { error: Error.TeamNotFound });
   });
 
   it('should fail because the token is not provided', async () => {
-    await request(app).post(`/teams/${team.id}/join-requests`).expect(401, { error: Error.Unauthenticated });
+    await request(app)
+      .post(`/teams/${team.id}/join-requests`)
+      .send({ userType: UserType.player })
+      .expect(401, { error: Error.Unauthenticated });
   });
 
   it('should fail because the user is already in a team', async () => {
@@ -44,6 +49,7 @@ describe('POST /teams/:teamId/join-requests', () => {
 
     await request(app)
       .post(`/teams/${team.id}/join-requests`)
+      .send({ userType: UserType.player })
       .set('Authorization', `Bearer ${localToken}`)
       .expect(403, { error: Error.AlreadyInTeam });
   });
@@ -52,6 +58,7 @@ describe('POST /teams/:teamId/join-requests', () => {
     sandbox.stub(teamOperations, 'askJoinTeam').throws('Unexpected error');
     await request(app)
       .post(`/teams/${team.id}/join-requests`)
+      .send({ userType: UserType.player })
       .set('Authorization', `Bearer ${token}`)
       .expect(500, { error: Error.InternalServerError });
   });
@@ -61,17 +68,45 @@ describe('POST /teams/:teamId/join-requests', () => {
 
     await request(app)
       .post(`/teams/${lockedTeam.id}/join-requests`)
+      .send({ userType: UserType.player })
       .set('Authorization', `Bearer ${token}`)
       .expect(403, { error: Error.TeamLocked });
   });
 
-  it('should succesfully request to join a team', async () => {
+  it('should not allow orga userType', async () => {
+    await request(app)
+      .post(`/teams/${team.id}/join-requests`)
+      .send({ userType: UserType.orga })
+      .set('Authorization', `Bearer ${token}`)
+      .expect(400, { error: Error.InvalidBody });
+  });
+
+  it('should succesfully request to join a team as a coach', async () => {
     const { body } = await request(app)
       .post(`/teams/${team.id}/join-requests`)
+      .send({ userType: UserType.coach })
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
     expect(body.askingTeamId).to.be.equal(team.id);
+    expect(body.type).to.be.equal(UserType.coach);
+
+    // Check if the object was filtered
+    expect(body.updatedAt).to.be.undefined;
+
+    // Delete request for next tests
+    await teamOperations.deleteTeamRequest(user.id);
+  });
+
+  it('should succesfully request to join a team as a player', async () => {
+    const { body } = await request(app)
+      .post(`/teams/${team.id}/join-requests`)
+      .send({ userType: UserType.player })
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(body.askingTeamId).to.be.equal(team.id);
+    expect(body.type).to.be.equal(UserType.player);
 
     // Check if the object was filtered
     expect(body.updatedAt).to.be.undefined;
@@ -80,6 +115,7 @@ describe('POST /teams/:teamId/join-requests', () => {
   it('should fail as we already asked for the same team', async () => {
     await request(app)
       .post(`/teams/${team.id}/join-requests`)
+      .send({ userType: UserType.player })
       .set('Authorization', `Bearer ${token}`)
       .expect(403, { error: Error.AlreadyAskedATeam });
   });
@@ -89,6 +125,7 @@ describe('POST /teams/:teamId/join-requests', () => {
 
     await request(app)
       .post(`/teams/${otherTeam.id}/join-requests`)
+      .send({ userType: UserType.player })
       .set('Authorization', `Bearer ${token}`)
       .expect(403, { error: Error.AlreadyAskedATeam });
   });

--- a/tests/teams/deleteTeam.test.ts
+++ b/tests/teams/deleteTeam.test.ts
@@ -80,5 +80,6 @@ describe('DELETE /teams/current', () => {
 
     const updatedCaptain = await fetchUser(captain.id);
     expect(updatedCaptain.teamId).to.be.null;
+    expect(updatedCaptain.type).to.be.null;
   });
 });

--- a/tests/teams/kickUser.test.ts
+++ b/tests/teams/kickUser.test.ts
@@ -104,7 +104,7 @@ describe('DELETE /teams/current/users/:userId', () => {
       .expect(404, { error: Error.UserNotFound });
   });
 
-  it('should succesfully kick the user (as the captain of the team and as a player)', async () => {
+  it('should successfully kick the user (as the captain of the team and as a player)', async () => {
     await request(app)
       .delete(`/teams/current/users/${userToKick.id}`)
       .set('Authorization', `Bearer ${captainToken}`)
@@ -112,12 +112,13 @@ describe('DELETE /teams/current/users/:userId', () => {
 
     const kickedUser = await fetchUser(userToKick.id);
     expect(kickedUser.teamId).to.be.null;
+    expect(kickedUser.type).to.be.null;
 
     // Rejoin the team for next tests
-    await teamOperations.joinTeam(team.id, kickedUser);
+    await teamOperations.joinTeam(team.id, kickedUser, UserType.player);
   });
 
-  it('should succesfully kick the user (as the captain of the team and as a coach)', async () => {
+  it('should successfully kick the user (as the captain of the team and as a coach)', async () => {
     const captain = getCaptain(team);
 
     // Set the captain to a coach
@@ -130,6 +131,7 @@ describe('DELETE /teams/current/users/:userId', () => {
 
     const kickedUser = await fetchUser(userToKick.id);
     expect(kickedUser.teamId).to.be.null;
+    expect(kickedUser.type).to.be.null;
   });
 
   it('should fail as the user has already been kicked', async () => {

--- a/tests/teams/leaveTeam.test.ts
+++ b/tests/teams/leaveTeam.test.ts
@@ -9,6 +9,7 @@ import { createFakeTeam } from '../utils';
 import { generateToken } from '../../src/utils/users';
 import { fetchUser } from '../../src/operations/user';
 import { getCaptain } from '../../src/utils/teams';
+import { UserType } from '.prisma/client';
 
 describe('DELETE /teams/current/users/current', () => {
   let user: User;
@@ -69,8 +70,9 @@ describe('DELETE /teams/current/users/current', () => {
     const removedUser = await fetchUser(user.id);
 
     expect(removedUser.teamId).to.be.null;
+    expect(removedUser.type).to.be.null;
 
     // Rejoin the team for next tests
-    await teamOperations.joinTeam(team.id, removedUser);
+    await teamOperations.joinTeam(team.id, removedUser, UserType.player);
   });
 });

--- a/tests/teams/refuseTeamRequest.test.ts
+++ b/tests/teams/refuseTeamRequest.test.ts
@@ -9,6 +9,7 @@ import { createFakeUser, createFakeTeam } from '../utils';
 import { generateToken } from '../../src/utils/users';
 import { fetchUser } from '../../src/operations/user';
 import { getCaptain } from '../../src/utils/teams';
+import { UserType } from '.prisma/client';
 
 describe('DELETE /teams/current/join-requests/:userId', () => {
   let user: User;
@@ -19,7 +20,7 @@ describe('DELETE /teams/current/join-requests/:userId', () => {
   before(async () => {
     team = await createFakeTeam({ members: 2 });
     user = await createFakeUser();
-    await teamOperations.askJoinTeam(team.id, user.id);
+    await teamOperations.askJoinTeam(team.id, user.id, UserType.player);
 
     captain = getCaptain(team);
     captainToken = generateToken(captain);
@@ -100,6 +101,7 @@ describe('DELETE /teams/current/join-requests/:userId', () => {
       .expect(204);
     const deletedRequestUser = await fetchUser(user.id);
     expect(deletedRequestUser.askingTeamId).to.be.null;
+    expect(deletedRequestUser.type).to.be.null;
   });
 
   it('should fail as the user has removed the request', async () => {

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -57,7 +57,7 @@ export const createFakeTeam = async ({
   name?: string;
 } = {}) => {
   const user = await createFakeUser({ paid });
-  const team = await createTeam(name || faker.internet.userName(), tournament, user.id);
+  const team = await createTeam(name || faker.internet.userName(), tournament, user.id, UserType.player);
 
   if (locked) {
     await lockTeam(team.id);
@@ -66,7 +66,7 @@ export const createFakeTeam = async ({
   // Create new members (minus 1 because the captain is already created)
   for (let index = 0; index < members - 1; index += 1) {
     const partner = await createFakeUser({ paid });
-    await joinTeam(team.id, partner);
+    await joinTeam(team.id, partner, UserType.player);
   }
 
   return fetchTeam(team.id);


### PR DESCRIPTION
Les utilisateurs choisissent désormais leur type (joueur ou coach) lorsqu'ils rejoignent une équipe (création d'équipe ou join request)
* Mise à jour de la doc openapi
* **Mise à jour du schéma de la base de données** (pensez bien à `yarn prisma generate`)
* Changement des routes suivantes:
  * `POST /auth/register`: suppression du paramètre `type`
  * `POST /teams`: ajout du paramètre `captainType`
  * `POST /teams/:teamId/join-requests`: ajout du paramètre `userType`