### PR TITLE
feat / custom-message

### DIFF
--- a/schema.prisma
+++ b/schema.prisma
@@ -121,6 +121,7 @@ model User {
   registerToken String?    @unique
   resetToken    String?    @unique
   place         String?    @unique
+  customMessage String?
   scannedAt     DateTime?
   discordId     String?    @unique
   teamId        String?

--- a/src/controllers/admin/openapi.yml
+++ b/src/controllers/admin/openapi.yml
@@ -207,7 +207,7 @@
                 users:
                   type: array
                   items:
-                    $ref: '#/components/schemas/UserWithTeam'
+                    $ref: '#/components/schemas/UserWithTeamAndMessage'
       400:
         $ref: '#/components/responses/400Errored'
       401:
@@ -260,7 +260,7 @@
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/User'
+              $ref: '#/components/schemas/UserWithMessage'
       400:
         $ref: '#/components/responses/400Errored'
       401:
@@ -469,7 +469,7 @@
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UserWithTeam'
+              $ref: '#/components/schemas/UserWithTeamAndMessage'
       400:
         $ref: '#/components/responses/400Errored'
       401:

--- a/src/controllers/admin/scan/scan.ts
+++ b/src/controllers/admin/scan/scan.ts
@@ -2,7 +2,7 @@ import Joi from 'joi';
 import { NextFunction, Request, Response } from 'express';
 import { hasPermission } from '../../../middlewares/authentication';
 import { Permission, Error } from '../../../types';
-import { badRequest, forbidden, noContent, notFound, success } from '../../../utils/responses';
+import { badRequest, forbidden, notFound, success } from '../../../utils/responses';
 import { decrypt } from '../../../utils/helpers';
 import logger from '../../../utils/logger';
 import { fetchUser, scanUser } from '../../../operations/user';

--- a/src/controllers/admin/scan/scan.ts
+++ b/src/controllers/admin/scan/scan.ts
@@ -2,11 +2,12 @@ import Joi from 'joi';
 import { NextFunction, Request, Response } from 'express';
 import { hasPermission } from '../../../middlewares/authentication';
 import { Permission, Error } from '../../../types';
-import { badRequest, forbidden, noContent, notFound } from '../../../utils/responses';
+import { badRequest, forbidden, noContent, notFound, success } from '../../../utils/responses';
 import { decrypt } from '../../../utils/helpers';
 import logger from '../../../utils/logger';
 import { fetchUser, scanUser } from '../../../operations/user';
 import { validateBody } from '../../../middlewares/validation';
+import { filterUser } from '../../../utils/filters';
 
 export default [
   // Middlewares
@@ -49,7 +50,7 @@ export default [
 
       await scanUser(user.id);
 
-      return noContent(response);
+      return success(response, { ...filterUser(user), customMessage: user.customMessage });
     } catch (error) {
       return next(error);
     }

--- a/src/controllers/admin/users/getUsers.ts
+++ b/src/controllers/admin/users/getUsers.ts
@@ -43,7 +43,10 @@ export default [
         currentPage: page,
         totalItems: 0,
         totalPages: 0,
-        users: users.map(filterUserWithTeam),
+        users: users.map((user) => ({
+          ...filterUserWithTeam(user),
+          customMessage: user.customMessage,
+        })),
       });
     } catch (error) {
       return next(error);

--- a/src/controllers/admin/users/updateUser.ts
+++ b/src/controllers/admin/users/updateUser.ts
@@ -17,6 +17,7 @@ export default [
       permissions: Joi.array().optional().items(validators.permission.optional()),
       place: validators.place.optional(),
       discordId: validators.discordId.optional(),
+      customMessage: Joi.string().optional(),
     }),
   ),
 
@@ -30,7 +31,7 @@ export default [
         return notFound(response, Error.UserNotFound);
       }
 
-      const { type, place, permissions, discordId } = request.body;
+      const { type, place, permissions, discordId, customMessage } = request.body;
 
       // Check that the user type hasn't changed if the user is paid
       if (user.hasPaid && user.type !== type) {
@@ -42,9 +43,10 @@ export default [
         permissions,
         place,
         discordId,
+        customMessage,
       });
 
-      return success(response, filterUser(updatedUser));
+      return success(response, { ...filterUser(updatedUser), customMessage: updatedUser.customMessage });
     } catch (error) {
       return next(error);
     }

--- a/src/controllers/auth/register.ts
+++ b/src/controllers/auth/register.ts
@@ -17,16 +17,16 @@ export default [
       lastname: validators.lastname.required(),
       email: validators.email.required(),
       password: validators.password.required(),
+      customMessage: Joi.string().optional(),
     }),
   ),
 
   // Controller
   async (request: Request, response: Response, next: NextFunction) => {
-    const { username, firstname, lastname, email, password } = request.body;
-
+    const { username, firstname, lastname, email, password, customMessage } = request.body;
     // Tries to create a user
     try {
-      await createUser(username, firstname, lastname, email, password);
+      await createUser({ username, firstname, lastname, email, password, customMessage });
     } catch (error) {
       // If the email already exists in the database, throw a bad request
       if (error.code === 'P2002' && error.meta && error.meta.target === 'email_unique')

--- a/src/controllers/openapi.yml
+++ b/src/controllers/openapi.yml
@@ -205,6 +205,22 @@ components:
             team:
               $ref: '#/components/schemas/Team'
 
+    UserWithMessage:
+      allOf:
+        - $ref: '#/components/schemas/User'
+        - type: object
+          properties:
+            customMessage:
+              type: string
+
+    UserWithTeamAndMessage:
+      allOf:
+        - $ref: '#/components/schemas/UserWithTeam'
+        - type: object
+          properties:
+            customMessage:
+              type: string
+
     Cart:
       type: object
       properties:

--- a/src/operations/user.ts
+++ b/src/operations/user.ts
@@ -129,6 +129,7 @@ export const updateAdminUser = async (
     permissions?: Permission[];
     place?: string;
     discordId?: string;
+    customMessage?: string;
   },
 ): Promise<User> => {
   const user = await database.user.update({
@@ -137,6 +138,7 @@ export const updateAdminUser = async (
       permissions: serializePermissions(updates.permissions),
       place: updates.place,
       discordId: updates.discordId,
+      customMessage: updates.customMessage,
     },
     where: { id: userId },
     include: userInclusions,

--- a/src/operations/user.ts
+++ b/src/operations/user.ts
@@ -78,28 +78,30 @@ export const fetchUsers = async (query: UserSearchQuery, page: number): Promise<
   return users.map(formatUserWithTeam);
 };
 
-export const createUser = async (
-  username: string,
-  firstname: string,
-  lastname: string,
-  email: string,
-  password: string,
-  discordId?: string,
-  type?: UserType,
-) => {
+export const createUser = async (user: {
+  username: string;
+  firstname: string;
+  lastname: string;
+  email: string;
+  password: string;
+  discordId?: string;
+  type?: UserType;
+  customMessage?: string;
+}) => {
   const salt = await userOperations.genSalt(env.bcrypt.rounds);
-  const hashedPassword = await userOperations.hash(password, salt);
+  const hashedPassword = await userOperations.hash(user.password, salt);
   return database.user.create({
     data: {
       id: nanoid(),
-      username,
-      firstname,
-      lastname,
-      email,
-      type,
-      discordId,
+      username: user.username,
+      firstname: user.firstname,
+      lastname: user.lastname,
+      email: user.email,
+      type: user.type,
+      discordId: user.discordId,
       password: hashedPassword,
       registerToken: nanoid(),
+      customMessage: user.customMessage,
     },
   });
 };

--- a/tests/admin/scan/scan.test.ts
+++ b/tests/admin/scan/scan.test.ts
@@ -21,7 +21,6 @@ describe('POST /admin/scan/:qrcode', () => {
 
   before(async () => {
     user = await createFakeUser();
-    user = await userOperations.updateAdminUser(user.id, { customMessage: "Controler l'autorisation parentale" });
     admin = await createFakeUser({ permission: Permission.entry });
     adminToken = generateToken(admin);
 
@@ -105,13 +104,14 @@ describe('POST /admin/scan/:qrcode', () => {
       .expect(500, { error: Error.InternalServerError });
   });
 
-  it('should scan the ticket and return the custom message', async () => {
+  it('should scan the ticket and return the updated user', async () => {
     const userData = await request(app)
       .post('/admin/scan')
       .send(validBody)
       .set('Authorization', `Bearer ${adminToken}`)
       .expect(200);
-    return expect(userData.body.customMessage).to.be.equal(user.customMessage);
+    expect(userData.body.customMessage).to.be.equal(user.customMessage);
+    return expect(userData.body.scannedAt).not.to.be.equal(null);
   });
 
   it('should error as the ticket is already scanned', () =>

--- a/tests/admin/users/getUsers.test.ts
+++ b/tests/admin/users/getUsers.test.ts
@@ -62,7 +62,7 @@ describe('GET /admin/users', () => {
       .expect(500, { error: Error.InternalServerError });
   });
 
-  it('shoud fetch one user', async () => {
+  it('should fetch one user', async () => {
     const { body } = await request(app).get(`/admin/users`).set('Authorization', `Bearer ${adminToken}`).expect(200);
 
     expect(body.itemsPerPage).to.be.equal(env.api.itemsPerPage);
@@ -85,6 +85,7 @@ describe('GET /admin/users', () => {
       type: user.type,
       username: user.username,
       hasPaid: false,
+      customMessage: null,
     });
   });
 
@@ -246,7 +247,7 @@ describe('GET /admin/users', () => {
       expect(body.users.length).to.be.equal(1);
     });
 
-    it('should return two non scanned user (including the admin', async () => {
+    it('should return two non scanned user (including the admin)', async () => {
       await database.user.update({ data: { scannedAt: null }, where: { id: user.id } });
       const { body } = await request(app)
         .get(`/admin/users?scanned=false`)

--- a/tests/admin/users/updateUser.test.ts
+++ b/tests/admin/users/updateUser.test.ts
@@ -105,7 +105,7 @@ describe('PATCH /admin/users/:userId', () => {
     expect(body.place).to.be.equal(validBody.place);
   });
 
-  it('should work be able to update discordId only', async () => {
+  it('should be able to update discordId only', async () => {
     const { body } = await request(app)
       .patch(`/admin/users/${user.id}`)
       .send({
@@ -114,7 +114,19 @@ describe('PATCH /admin/users/:userId', () => {
       .set('Authorization', `Bearer ${adminToken}`)
       .expect(200);
 
-    expect(body.place).to.be.equal(validBody.place);
+    expect(body.discordId).to.be.equal('627536251278278');
+  });
+
+  it('should be able to update customMessage only', async () => {
+    const { body } = await request(app)
+      .patch(`/admin/users/${user.id}`)
+      .send({
+        customMessage: 'Autorisation parentale',
+      })
+      .set('Authorization', `Bearer ${adminToken}`)
+      .expect(200);
+
+    expect(body.customMessage).to.be.equal('Autorisation parentale');
   });
 
   it('should fail as the user has already paid and wants to change its type', async () => {

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -30,6 +30,7 @@ export const createFakeUser = async ({
   paid = false,
   discordId = `${Math.floor(Date.now() * (1 + Math.random()))}`,
   permission,
+  customMessage,
 }: {
   username?: string;
   firstname?: string;
@@ -41,8 +42,18 @@ export const createFakeUser = async ({
   paid?: boolean;
   discordId?: string;
   permission?: Permission;
+  customMessage?: string;
 } = {}): Promise<User> => {
-  const user: prisma.User = await createUser(username, firstname, lastname, email, password, discordId, type);
+  const user: prisma.User = await createUser({
+    username,
+    firstname,
+    lastname,
+    email,
+    password,
+    discordId,
+    type,
+    customMessage,
+  });
   logger.verbose(`Created user ${user.username}`);
 
   if (confirmed) {


### PR DESCRIPTION
Ajout d'un champ de message custom dans la table user.

- Le scan  du billet retourne maintenant l'utilisateur et le message
- Le message est également renvoyé par le get /admin/users
- Possibilité de modifier le message depuis le patch /admin/users/{userId}
- Ajout du customMessage dans la db
- Ajout des tests