### PR TITLE
feat(user): attendants and spectators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,8 @@ yarn-error.log
 /dbml
 
 # IDE Configs
-/.idea
+.idea
+.vscode
 
 /local
 

--- a/schema.prisma
+++ b/schema.prisma
@@ -63,26 +63,26 @@ model Setting {
 }
 
 model Team {
-  id           String         @id
+  id           String       @id
   name         String
   tournamentId TournamentId
-  captainId    String         @unique
+  captainId    String       @unique
   lockedAt     DateTime?
-  createdAt    DateTime       @default(now())
-  updatedAt    DateTime       @default(now()) @updatedAt
-  captain      User           @relation(fields: [captainId], references: [id])
-  tournament   Tournament     @relation(fields: [tournamentId], references: [id])
-  askingUsers  User[]         @relation("teamAskingUsers")
-  users        User[]         @relation("teamUsers")
+  createdAt    DateTime     @default(now())
+  updatedAt    DateTime     @default(now()) @updatedAt
+  captain      User         @relation(fields: [captainId], references: [id])
+  tournament   Tournament   @relation(fields: [tournamentId], references: [id])
+  askingUsers  User[]       @relation("teamAskingUsers")
+  users        User[]       @relation("teamUsers")
 
-  @@index([id])
   @@unique([name, tournamentId])
+  @@index([id])
   @@map("teams")
 }
 
 model Tournament {
-  id                     TournamentId  @id
-  name                   String  @unique
+  id                     TournamentId @id
+  name                   String       @unique
   maxPlayers             Int
   playersPerTeam         Int
   toornamentId           String?
@@ -96,13 +96,13 @@ model Tournament {
 }
 
 model Log {
-  id               String     @id
-  method           String
-  path             String
-  body             Json?
-  userId           String
-  createdAt        DateTime        @default(now())
-  user             User            @relation(fields: [userId], references: [id])
+  id        String   @id
+  method    String
+  path      String
+  body      Json?
+  userId    String
+  createdAt DateTime @default(now())
+  user      User     @relation(fields: [userId], references: [id])
 
   // We create an index on the userId as the search most of the time used with a userId
   @@index([userId])
@@ -110,30 +110,36 @@ model Log {
 }
 
 model User {
-  id            String     @id
-  username      String?    @unique
-  firstname     String
-  lastname      String
-  email         String?    @unique
-  password      String?
-  type          UserType?
-  permissions   String?
-  registerToken String?    @unique
-  resetToken    String?    @unique
-  place         String?    @unique
-  customMessage String?
-  scannedAt     DateTime?
-  discordId     String?    @unique
-  teamId        String?
-  askingTeamId  String?
-  createdAt     DateTime   @default(now())
-  updatedAt     DateTime   @default(now()) @updatedAt
-  askingTeam    Team?      @relation("teamAskingUsers", fields: [askingTeamId], references: [id])
-  team          Team?      @relation("teamUsers", fields: [teamId], references: [id])
-  captainTeam   Team?      // This field is used to make prisma work but should never be used
-  cartItems     CartItem[]
-  carts         Cart[]
-  logs          Log[]
+  id              String     @id
+  username        String?    @unique
+  firstname       String
+  lastname        String
+  email           String?    @unique
+  password        String?
+  type            UserType?
+  age             UserAge    @default(child)
+  permissions     String?
+  registerToken   String?    @unique
+  resetToken      String?    @unique
+  place           String?    @unique
+  customMessage   String?
+  scannedAt       DateTime?
+  discordId       String?    @unique
+  // Attendant: both sides relation is required by prisma. Read docs:
+  // https://www.prisma.io/docs/concepts/components/prisma-schema/relations/self-relations#one-to-one-self-relations
+  attendantId     String?    @unique
+  attendant       User?      @relation("attendantUser", fields: [attendantId], references: [id])
+  attended        User?      @relation("attendantUser")
+  teamId          String?
+  askingTeamId    String?
+  createdAt       DateTime   @default(now())
+  updatedAt       DateTime   @default(now()) @updatedAt
+  askingTeam      Team?      @relation("teamAskingUsers", fields: [askingTeamId], references: [id])
+  team            Team?      @relation("teamUsers", fields: [teamId], references: [id])
+  captainTeam     Team?      // This field is used to make prisma work but should never be used
+  cartItems       CartItem[]
+  carts           Cart[]
+  logs            Log[]
 
   @@index([id])
   @@map("users")
@@ -154,9 +160,15 @@ enum ItemCategory {
 
 enum UserType {
   player
-  coach
-  visitor
   orga
+  coach
+  spectator
+  attendant
+}
+
+enum UserAge {
+  adult
+  child
 }
 
 enum TournamentId {

--- a/seed.sql
+++ b/seed.sql
@@ -1,7 +1,8 @@
 INSERT INTO `items` (`id`, `name`, `category`, `attribute`, `price`, `reducedPrice`, `infos`, `image`, `stock`) VALUES
-('ticket-player', 'Place joueur', 'ticket', NULL, 1500, 1100, NULL, NULL, NULL),
-('ticket-coach', 'Place coach', 'ticket', NULL, 1200, NULL, NULL, NULL, 40),
-('ticket-visitor', 'Place accompagnateur', 'ticket', NULL, 1200, NULL, NULL, NULL, 60),
+('ticket-player', 'Place joueur', 'ticket', NULL, 2000, 1500, NULL, NULL, NULL),
+('ticket-coach', 'Place coach/manager', 'ticket', NULL, 1200, NULL, NULL, NULL, NULL),
+('ticket-attendant', 'Place accompagnateur', 'ticket', NULL, 1200, NULL, NULL, NULL, NULL),
+('ticket-spectator', 'Place spectateur', 'ticket', NULL, 1200, 1000, NULL, NULL, 50),
 ('discount-switch-ssbu', 'Réduction si tu amènes ta propre Nintendo Switch', 'supplement', NULL, -300, NULL, 'Une réduction applicable si tu amènes ta propre Nintendo Switch pendant le weekend', NULL, 16),
 ('ethernet-5', 'Câble ethernet (5m)', 'supplement', NULL, 700, NULL, 'Un câble ethernet est requis pour se brancher aux switchs des tables', NULL, 30),
 ('ethernet-7', 'Câble ethernet (7m)', 'supplement', NULL, 1000, NULL, 'Un câble ethernet plus long pour les joueurs situés en bout de table', NULL, 30),

--- a/src/controllers/admin/auth/login.ts
+++ b/src/controllers/admin/auth/login.ts
@@ -25,8 +25,8 @@ export default [
         return forbidden(response, Error.EmailNotConfirmed);
       }
 
-      if (user.type === UserType.visitor) {
-        return forbidden(response, Error.LoginAsVisitor);
+      if (user.type === UserType.attendant) {
+        return forbidden(response, Error.LoginAsAttendant);
       }
 
       // Generate a token

--- a/src/controllers/admin/openapi.yml
+++ b/src/controllers/admin/openapi.yml
@@ -254,6 +254,9 @@
                 type: string
                 example: '1420070400000'
                 nullable: true
+              age:
+                $ref: '#/components/schemas/Age'
+                nullable: true
     responses:
       200:
         description: L'utilisateur a bien été modifié. Ses informations sont renvoyées.

--- a/src/controllers/admin/openapi.yml
+++ b/src/controllers/admin/openapi.yml
@@ -272,6 +272,8 @@
         $ref: '#/components/responses/403Unauthorized'
       404:
         $ref: '#/components/responses/404UserNotFound'
+      409:
+        $ref: '#/components/responses/409PlaceAlreadyAttributed'
 
 /admin/users/{userId}/carts:
   get:

--- a/src/controllers/admin/users/updateUser.ts
+++ b/src/controllers/admin/users/updateUser.ts
@@ -14,6 +14,7 @@ export default [
   validateBody(
     Joi.object({
       type: validators.type.optional(),
+      age: validators.age.optional(),
       permissions: Joi.array().optional().items(validators.permission.optional()),
       place: validators.place.optional(),
       discordId: validators.discordId.optional(),
@@ -31,10 +32,10 @@ export default [
         return notFound(response, Error.UserNotFound);
       }
 
-      const { type, place, permissions, discordId, customMessage } = request.body;
+      const { type, place, permissions, discordId, customMessage, age } = request.body;
 
       // Check that the user type hasn't changed if the user is paid
-      if (user.hasPaid && user.type !== type) {
+      if (type !== undefined && user.hasPaid && user.type !== type) {
         return forbidden(response, Error.CannotChangeType);
       }
 
@@ -44,6 +45,7 @@ export default [
         place,
         discordId,
         customMessage,
+        age,
       });
 
       return success(response, { ...filterUser(updatedUser), customMessage: updatedUser.customMessage });

--- a/src/controllers/auth/login.ts
+++ b/src/controllers/auth/login.ts
@@ -47,8 +47,8 @@ export default [
         return forbidden(response, Error.EmailNotConfirmed);
       }
 
-      if (user.type === UserType.visitor) {
-        return forbidden(response, Error.LoginAsVisitor);
+      if (user.type === UserType.attendant) {
+        return forbidden(response, Error.LoginAsAttendant);
       }
 
       // Compares the hash from the password given

--- a/src/controllers/auth/openapi.yml
+++ b/src/controllers/auth/openapi.yml
@@ -69,8 +69,8 @@
               password:
                 type: string
                 minLength: 6
-              discordId:
-                type: string
+              age:
+                $ref: '#/components/schemas/Age'
     responses:
       201:
         description: L'utilisateur a bien été créé

--- a/src/controllers/auth/register.ts
+++ b/src/controllers/auth/register.ts
@@ -20,16 +20,23 @@ export default [
       lastname: validators.lastname.required(),
       email: validators.email.required(),
       password: validators.password.required(),
-      customMessage: Joi.string().optional(),
+      age: validators.age.required(),
     }),
   ),
 
   // Controller
   async (request: Request, response: Response, next: NextFunction) => {
-    const { username, firstname, lastname, email, password, customMessage } = request.body;
+    const { username, firstname, lastname, email, password, age } = request.body;
     // Tries to create a user
     try {
-      const registeredUser = await createUser({ username, firstname, lastname, email, password, customMessage });
+      const registeredUser = await createUser({
+        username,
+        firstname,
+        lastname,
+        email,
+        password,
+        age,
+      });
 
       // Send registration token by mail
       // Don't send sync when it is not needed

--- a/src/controllers/discord/openapi.yml
+++ b/src/controllers/discord/openapi.yml
@@ -22,6 +22,8 @@
     description: Génère un lien oauth discord pour lier son compte
     tags:
       - Discord
+    security:
+      - BearerAuth: []
     responses:
       200:
         description: Lien Oauth généré

--- a/src/controllers/openapi.yml
+++ b/src/controllers/openapi.yml
@@ -111,6 +111,18 @@ components:
         hasPaid:
           type: boolean
 
+    UserAttendant:
+      type: object
+      description: L'accompagnateur d'un mineur. Cet accompagnateur sera toujours majeur (donc omis de la réponse)
+      properties:
+        id:
+          type: string
+          example: F3SHNV
+        firstname:
+          type: string
+        lastname:
+          type: string
+
     User:
       allOf:
         - $ref: '#/components/schemas/UserRestricted'
@@ -148,6 +160,9 @@ components:
             askingTeamId:
               type: string
               example: I8YNHK
+              nullable: true
+            attendant:
+              $ref: '#/components/schemas/UserAttendant'
               nullable: true
 
     Team:

--- a/src/controllers/openapi.yml
+++ b/src/controllers/openapi.yml
@@ -389,7 +389,8 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
-          example: Ce nom d'utilisateur est déjà utilisé
+          example:
+            error: Ce nom d'utilisateur est déjà utilisé
 
     409PlaceAlreadyAttributed:
       description: La place est déjà attribuée
@@ -397,4 +398,5 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
-          example: Cette place est déjà attribuée
+          example:
+            error: Cette place est déjà attribuée

--- a/src/controllers/openapi.yml
+++ b/src/controllers/openapi.yml
@@ -98,7 +98,7 @@ components:
 
     UserRestricted:
       type: object
-      description: Utilisateur informations personnelles. ⚠ Un visiteur ne peut pas être affiché car il n'a pas de username ⚠
+      description: Utilisateur informations personnelles. ⚠ Un accompagnateur ne peut pas être affiché car il n'a pas de username ⚠
       properties:
         id:
           type: string
@@ -382,3 +382,19 @@ components:
             $ref: '#/components/schemas/Error'
           example:
             error: Le panier est introuvable
+
+    409UsernameAlreadyExists:
+      description: Le nom d'utilisateur existe déjà
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example: Ce nom d'utilisateur est déjà utilisé
+
+    409PlaceAlreadyAttributed:
+      description: La place est déjà attribuée
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example: Cette place est déjà attribuée

--- a/src/controllers/openapi.yml
+++ b/src/controllers/openapi.yml
@@ -64,18 +64,22 @@ components:
 
     Type:
       type: string
-      enum: [player, coach, visitor, orga]
+      enum: [player, orga, coach, spectator, attendant]
 
     Permission:
       type: string
       enum: [stream, entry, anim, admin]
+
+    Age:
+      type: string
+      enum: [child, adult]
 
     Tournament:
       type: object
       properties:
         id:
           type: string
-          example: lol-pro
+          example: lolCompetitive
         name:
           type: string
         shortName:

--- a/src/controllers/teams/createTeam.ts
+++ b/src/controllers/teams/createTeam.ts
@@ -2,7 +2,7 @@ import { UserType } from '@prisma/client';
 import { NextFunction, Request, Response } from 'express';
 import Joi from 'joi';
 import { hasLinkedDiscordAccount } from '../../middlewares/oauth';
-import { isNotInATeam } from '../../middlewares/team';
+import { noSpectator } from '../../middlewares/team';
 import { validateBody } from '../../middlewares/validation';
 import { createTeam } from '../../operations/team';
 import { fetchTournament } from '../../operations/tournament';
@@ -13,7 +13,7 @@ import * as validators from '../../utils/validators';
 
 export default [
   // Middlewares
-  ...isNotInATeam,
+  ...noSpectator,
   hasLinkedDiscordAccount,
   validateBody(
     Joi.object({

--- a/src/controllers/teams/createTeamRequest.ts
+++ b/src/controllers/teams/createTeamRequest.ts
@@ -41,7 +41,7 @@ export default [
       return success(response, filterUser(updatedUser));
     } catch (error) {
       // This may happen when max coach amount is reached already
-      if (error.code === 'API_MAX_COACH') return forbidden(response, Error.TeamMaxCoachReached);
+      if (error.code === 'API_COACH_MAX_TEAM') return forbidden(response, Error.TeamMaxCoachReached);
 
       return next(error);
     }

--- a/src/controllers/teams/createTeamRequest.ts
+++ b/src/controllers/teams/createTeamRequest.ts
@@ -40,6 +40,9 @@ export default [
 
       return success(response, filterUser(updatedUser));
     } catch (error) {
+      // This may happen when max coach amount is reached already
+      if (error.code === 'API_MAX_COACH') return forbidden(response, Error.TeamMaxCoachReached);
+
       return next(error);
     }
   },

--- a/src/controllers/teams/createTeamRequest.ts
+++ b/src/controllers/teams/createTeamRequest.ts
@@ -2,7 +2,7 @@ import { UserType } from '@prisma/client';
 import { NextFunction, Request, Response } from 'express';
 import Joi from 'joi';
 import { hasLinkedDiscordAccount } from '../../middlewares/oauth';
-import { isNotInATeam } from '../../middlewares/team';
+import { noSpectator } from '../../middlewares/team';
 import { validateBody } from '../../middlewares/validation';
 import { askJoinTeam, fetchTeam } from '../../operations/team';
 import { Error } from '../../types';
@@ -12,7 +12,7 @@ import { getRequestInfo } from '../../utils/users';
 
 export default [
   // Middlewares
-  ...isNotInATeam,
+  ...noSpectator,
   hasLinkedDiscordAccount,
   validateBody(
     Joi.object({

--- a/src/controllers/tournaments/openapi.yml
+++ b/src/controllers/tournaments/openapi.yml
@@ -17,4 +17,6 @@
                   - type: object
                     properties:
                       teams:
-                        $ref: '#/components/schemas/TeamWithUsersRestricted'
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/TeamWithUsersRestricted'

--- a/src/controllers/users/createCart.ts
+++ b/src/controllers/users/createCart.ts
@@ -155,7 +155,7 @@ export default [
       }
 
       // Calculate if each cart item is available
-      const itemsWithStock = items.filter((item) => item.left);
+      const itemsWithStock = items.filter((item) => item.left !== undefined);
 
       // Foreach item where there is a stock
       for (const item of itemsWithStock) {

--- a/src/controllers/users/createCart.ts
+++ b/src/controllers/users/createCart.ts
@@ -5,7 +5,7 @@ import { Basket } from '../../services/etupay';
 import { validateBody } from '../../middlewares/validation';
 import { createCart } from '../../operations/carts';
 import { fetchUserItems } from '../../operations/item';
-import { createVisitor, deleteUser, fetchUser } from '../../operations/user';
+import { createAttendant, deleteUser, fetchUser } from '../../operations/user';
 import { Cart, Error, PrimitiveCartItem } from '../../types';
 import { encodeToBase64, isPartnerSchool, removeAccents } from '../../utils/helpers';
 import { badRequest, created, forbidden, gone, notFound } from '../../utils/responses';
@@ -15,6 +15,7 @@ import { isShopAllowed } from '../../middlewares/settings';
 import { isAuthenticated } from '../../middlewares/authentication';
 
 export interface PayBody {
+  // TODO: remove visitors from there (replace with a single attendant)
   tickets: {
     userIds: string[];
     visitors: {
@@ -91,6 +92,7 @@ export default [
 
           // Otherwise, throws an error
         } else {
+          // IMPLEMENT: Spectators
           return forbidden(response, Error.NotPlayerOrCoach);
         }
 
@@ -131,7 +133,8 @@ export default [
         // Manage the visitor parts
         for (const visitor of body.tickets.visitors) {
           // Creates the visitor
-          const visitorUser = await createVisitor(visitor.firstname, visitor.lastname);
+          // TODO: Handle attendant creation
+          const visitorUser = await createAttendant(visitor.firstname, visitor.lastname);
 
           // Add the item to the basket
           cartItems.push({

--- a/src/controllers/users/createCart.ts
+++ b/src/controllers/users/createCart.ts
@@ -1,11 +1,11 @@
-import { ItemCategory, UserType } from '@prisma/client';
+import { ItemCategory, UserType, UserAge } from '@prisma/client';
 import { NextFunction, Request, Response } from 'express';
 import Joi from 'joi';
 import { Basket } from '../../services/etupay';
 import { validateBody } from '../../middlewares/validation';
 import { createCart } from '../../operations/carts';
 import { fetchUserItems } from '../../operations/item';
-import { createAttendant, deleteUser, fetchUser } from '../../operations/user';
+import { createAttendant, deleteUser, fetchUser, formatUser } from '../../operations/user';
 import { Cart, Error, PrimitiveCartItem } from '../../types';
 import { encodeToBase64, isPartnerSchool, removeAccents } from '../../utils/helpers';
 import { badRequest, created, forbidden, gone, notFound } from '../../utils/responses';
@@ -15,13 +15,12 @@ import { isShopAllowed } from '../../middlewares/settings';
 import { isAuthenticated } from '../../middlewares/authentication';
 
 export interface PayBody {
-  // TODO: remove visitors from there (replace with a single attendant)
   tickets: {
     userIds: string[];
-    visitors: {
+    attendant?: {
       firstname: string;
       lastname: string;
-    }[];
+    };
   };
   supplements: {
     itemId: string;
@@ -37,11 +36,9 @@ export default [
   validateBody(
     Joi.object({
       tickets: Joi.object({
-        // We add the optionnal to allow empty array
+        // Paying no ticket with this cart is possible, just provide an empty array
         userIds: Joi.array().items(validators.id.optional()).unique().required(),
-        visitors: Joi.array()
-          .items(Joi.object({ firstname: validators.firstname, lastname: validators.lastname }))
-          .required(),
+        attendant: Joi.object({ firstname: validators.firstname, lastname: validators.lastname }).optional(),
       }).required(),
       supplements: Joi.array()
         .items(
@@ -58,9 +55,12 @@ export default [
   // Controller
   async (request: Request, response: Response, next: NextFunction) => {
     try {
-      const { body } = request;
+      const { body } = request as { body: PayBody };
 
-      const { user, team } = getRequestInfo(response);
+      const requestInfo = getRequestInfo(response);
+      let { user } = requestInfo;
+      const { team } = requestInfo;
+
       const items = await fetchUserItems(team);
 
       const cartItems: PrimitiveCartItem[] = [];
@@ -79,21 +79,23 @@ export default [
           return forbidden(response, Error.AlreadyPaid);
         }
 
+        // Checks whether the user can have an attendant because he is an adult
+        if (user.age !== UserAge.child && body.tickets.attendant) return forbidden(response, Error.AttendantNotAllowed);
+
+        // Checks whether a child has already registered an attendant
+        if (user.attendantId && body.tickets.attendant) return forbidden(response, Error.AttendantAlreadyRegistered);
+
         // Defines the ticket id to be either a player or a coach
         let itemId;
 
-        // If the user is a player
-        if (ticketUser.type === UserType.player) {
-          itemId = 'ticket-player';
-
-          // If the user is a coach
-        } else if (ticketUser.type === UserType.coach) {
-          itemId = 'ticket-coach';
-
-          // Otherwise, throws an error
-        } else {
-          // IMPLEMENT: Spectators
-          return forbidden(response, Error.NotPlayerOrCoach);
+        switch (ticketUser.type) {
+          case UserType.player:
+          case UserType.coach:
+          case UserType.spectator:
+            itemId = `ticket-${ticketUser.type}`;
+            break;
+          default:
+            return forbidden(response, Error.NotPlayerOrCoachOrSpectator);
         }
 
         // Adds the item to the basket
@@ -120,7 +122,7 @@ export default [
 
       // Checks if the basket is empty and there is no visitors
       // This check is used before the visitors because the visitors write in database
-      if (cartItems.length === 0 && body.tickets.visitors.length === 0) {
+      if (cartItems.length === 0 && !body.tickets.attendant) {
         return badRequest(response, Error.EmptyBasket);
       }
 
@@ -128,30 +130,27 @@ export default [
       let cart: Cart;
 
       // We use a try here because we make SQL requests without a transaction
-      // The try catch ensures if the createVisitor or createCart fails, the create visitors are deleted
+      // The try catch ensures if the createAttendant or createCart fails, the created attendants are deleted
       try {
-        // Manage the visitor parts
-        for (const visitor of body.tickets.visitors) {
-          // Creates the visitor
-          // TODO: Handle attendant creation
-          const visitorUser = await createAttendant(visitor.firstname, visitor.lastname);
+        if (body.tickets.attendant) {
+          // Creates the attendant
+          user = formatUser(
+            await createAttendant(user.id, body.tickets.attendant.firstname, body.tickets.attendant.lastname),
+          );
 
           // Add the item to the basket
           cartItems.push({
-            itemId: 'ticket-visitor',
+            itemId: 'ticket-attendant',
             quantity: 1,
-            forUserId: visitorUser.id,
+            forUserId: user.attendantId,
           });
         }
 
         // Set the cart variable defined outside the try/catch block
         cart = await createCart(user.id, cartItems);
       } catch (error) {
-        await Promise.all(
-          cartItems
-            .filter((cartItem) => cartItem.itemId === 'ticket-visitor')
-            .map((cartItem) => deleteUser(cartItem.forUserId)),
-        );
+        const attendantTicket = cartItems.find((cartItem) => cartItem.itemId === 'ticket-attendant');
+        await deleteUser(attendantTicket.forUserId);
         return next(error);
       }
 

--- a/src/controllers/users/index.ts
+++ b/src/controllers/users/index.ts
@@ -8,7 +8,7 @@ const router = Router();
 
 router.get('/current', getUser);
 
-router.put('/current', updateUser);
+router.patch('/current', updateUser);
 router.post('/current/carts', createCart);
 router.get('/current/carts', getCarts);
 

--- a/src/controllers/users/index.ts
+++ b/src/controllers/users/index.ts
@@ -12,4 +12,7 @@ router.put('/current', updateUser);
 router.post('/current/carts', createCart);
 router.get('/current/carts', getCarts);
 
+// UPDATE : Add route /current/spectate for both post and delete methods
+// DOCS : Add route /current/spactate to docs
+
 export default router;

--- a/src/controllers/users/index.ts
+++ b/src/controllers/users/index.ts
@@ -3,6 +3,7 @@ import createCart from './createCart';
 import getCarts from './getCarts';
 import updateUser from './updateUser';
 import getUser from './getUser';
+import { become, leave } from './spectate';
 
 const router = Router();
 
@@ -12,7 +13,7 @@ router.patch('/current', updateUser);
 router.post('/current/carts', createCart);
 router.get('/current/carts', getCarts);
 
-// UPDATE : Add route /current/spectate for both post and delete methods
-// DOCS : Add route /current/spactate to docs
+router.post('/current/spectate', become);
+router.delete('/current/spectate', leave);
 
 export default router;

--- a/src/controllers/users/openapi.yml
+++ b/src/controllers/users/openapi.yml
@@ -1,6 +1,7 @@
 /users:
   get:
     summary: (Non implémentée cf. PR#57) Renvoie les informations minimales d'un utilisateur
+    deprecated: true
     description: Renvoie les informations minimales d'un utilisateur.
     tags:
       - Users

--- a/src/controllers/users/openapi.yml
+++ b/src/controllers/users/openapi.yml
@@ -1,6 +1,6 @@
 /users:
   get:
-    summary: Renvoie les informations minimales d'un utilisateur
+    summary: (Non implémentée cf. PR#57) Renvoie les informations minimales d'un utilisateur
     description: Renvoie les informations minimales d'un utilisateur.
     tags:
       - Users
@@ -133,9 +133,11 @@
                       type: string
                     example:
                       - V1STGX
-                  visitors:
-                    type: array
-                    description: Liste des billets accompagnateurs à acheter
+                  attendant:
+                    nullable: true
+                    type: object
+                    description: Identité de l'accompagnateur. Nécessite que l'utilisateur (actuel)
+                      soit mineur et ne soit pas déjà accompagné.
                     items:
                       type: object
                       properties:

--- a/src/controllers/users/openapi.yml
+++ b/src/controllers/users/openapi.yml
@@ -42,9 +42,10 @@
         $ref: '#/components/responses/400Errored'
       404:
         $ref: '#/components/responses/404UserNotFound'
-  put:
+  patch:
     summary: Modifie les informations d'un utilisateur
     description: Modifie les informations d'un utilisateur.
+      **Le mot de passe est nécessaire pour que la/les valeur(s) soi(en)t modifiée(s)**
     tags:
       - Users
     security:
@@ -58,9 +59,10 @@
             properties:
               username:
                 type: string
+                nullable: true
               password:
                 type: string
-                nullable: true
+                required: true
               newPassword:
                 type: string
                 nullable: true

--- a/src/controllers/users/openapi.yml
+++ b/src/controllers/users/openapi.yml
@@ -81,6 +81,8 @@
         $ref: '#/components/responses/403Unauthorized'
       404:
         $ref: '#/components/responses/404UserNotFound'
+      409:
+        $ref: '#/components/responses/409UsernameAlreadyExists'
 
 /users/current/carts:
   get:
@@ -184,3 +186,40 @@
         $ref: '#/components/responses/403Unauthorized'
       404:
         $ref: '#/components/responses/404UserNotFound'
+
+/users/current/spectate:
+  post:
+    summary: Transforme l'utilisateur en spectateur.
+    description: Transforme l'utilisateur en spectateur. Cette opération n'est possible que si l'utilisateur
+      n'est pas dans une équipe ou n'est a pas de demandes en attente.<br/>
+      Devenir un spectateur de cette façon **n'assure PAS à l'utilisateur d'avoir ticket** (de spectateur)
+    tags:
+      - Users
+    security:
+      - BearerAuth: []
+    responses:
+      200:
+        description: L'utilisateur est désormais spectateur
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+      403:
+        $ref: '#/components/responses/403Unauthorized'
+  delete:
+    summary: Transforme le spectateur en simple utilisateur.
+    description: Transforme le spectateur en simple utilisateur. Cette opération n'est possible que si l'utilisateur
+      n'a pas déjà payé son ticket (et si c'est un spectateur)
+    tags:
+      - Users
+    security:
+      - BearerAuth: []
+    responses:
+      200:
+        description: L'utilisateur n'est plus spectateur
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+      403:
+        $ref: '#/components/responses/403Unauthorized'

--- a/src/controllers/users/spectate.ts
+++ b/src/controllers/users/spectate.ts
@@ -1,0 +1,61 @@
+import Joi from 'joi';
+import type { Request, Response, NextFunction } from 'express';
+import { isNotInATeam } from '../../middlewares/team';
+import { validateBody } from '../../middlewares/validation';
+import { getRequestInfo } from '../../utils/users';
+import { forbidden, success } from '../../utils/responses';
+import { Error } from '../../types';
+import { updateAdminUser } from '../../operations/user';
+import { UserType } from '.prisma/client';
+
+export const become = [
+  // Middlewares
+  ...isNotInATeam,
+  validateBody(Joi.object({})),
+
+  // Controller
+  async (request: Request, response: Response, next: NextFunction) => {
+    const { user } = getRequestInfo(response);
+
+    // If the user has a type, it means he is in a team or waiting to
+    // be accepted in a team. He has to leave the team or cancel his
+    // request before trying to become spactator.
+    // IMPORTANT NOTE: becoming a {@link UserType#spectator} doesn't
+    // ensure you to get a spectator ticket
+    if (user.type) return forbidden(response, Error.CannotSpectate);
+
+    try {
+      const updatedUser = await updateAdminUser(user.id, {
+        type: UserType.spectator,
+      });
+      return success(response, updatedUser);
+    } catch (error) {
+      return next(error);
+    }
+  },
+];
+
+export const leave = [
+  // Middlewares
+  ...isNotInATeam,
+  validateBody(Joi.object({})),
+
+  // Controller
+  async (request: Request, response: Response, next: NextFunction) => {
+    const { user } = getRequestInfo(response);
+
+    // If the user has already paid, he can't discard his spectator ticket
+    if (user.hasPaid) return forbidden(response, Error.AlreadyPaid);
+    // The user is not a spectator: we send him an error
+    if (user.type !== UserType.spectator) return forbidden(response, Error.CannotUnSpectate);
+
+    try {
+      const updatedUser = await updateAdminUser(user.id, {
+        type: null,
+      });
+      return success(response, updatedUser);
+    } catch (error) {
+      return next(error);
+    }
+  },
+];

--- a/src/controllers/users/updateUser.ts
+++ b/src/controllers/users/updateUser.ts
@@ -16,9 +16,9 @@ export default [
 
   validateBody(
     Joi.object({
-      username: validators.username.required(),
+      username: validators.username.optional(),
       password: validators.password.required(),
-      newPassword: validators.password.required(),
+      newPassword: validators.password.optional(),
     }),
   ),
 
@@ -37,7 +37,7 @@ export default [
         return unauthenticated(response, Error.InvalidCredentials);
       }
 
-      const updatedUser = await updateUser(user.id, username, newPassword);
+      const updatedUser = await updateUser(user.id, { username, newPassword });
 
       return success(response, filterUser(updatedUser));
     } catch (error) {

--- a/src/controllers/users/updateUser.ts
+++ b/src/controllers/users/updateUser.ts
@@ -3,7 +3,7 @@ import bcrpyt from 'bcryptjs';
 import { NextFunction, Request, Response } from 'express';
 import { getRequestInfo } from '../../utils/users';
 import { filterUser } from '../../utils/filters';
-import { success, unauthenticated } from '../../utils/responses';
+import { conflict, success, unauthenticated } from '../../utils/responses';
 import { validateBody } from '../../middlewares/validation';
 import * as validators from '../../utils/validators';
 import { Error } from '../../types';
@@ -41,6 +41,10 @@ export default [
 
       return success(response, filterUser(updatedUser));
     } catch (error) {
+      // If the username is already used by someone else, we respond with an error
+      if (error.code === 'P2002' && error.meta && error.meta.target === 'username_unique')
+        return conflict(response, Error.UsernameAlreadyExists);
+
       return next(error);
     }
   },

--- a/src/middlewares/team.ts
+++ b/src/middlewares/team.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
+import { UserType } from '.prisma/client';
 import { Error } from '../types';
 import { forbidden } from '../utils/responses';
 import { getRequestInfo } from '../utils/users';
@@ -44,6 +45,20 @@ export const isInATeam = [
 
     if (!user.teamId) {
       return forbidden(response, Error.NotInTeam);
+    }
+
+    return next();
+  },
+];
+
+// Checks the user is not a team and not a spectator
+export const noSpectator = [
+  ...isNotInATeam,
+  (request: Request, response: Response, next: NextFunction): void => {
+    const { user } = getRequestInfo(response);
+
+    if (user.type === UserType.spectator) {
+      return forbidden(response, Error.NoSpectator);
     }
 
     return next();

--- a/src/middlewares/user.ts
+++ b/src/middlewares/user.ts
@@ -37,9 +37,9 @@ export const initUserRequest = async (request: Request, response: Response, next
       return forbidden(response, Error.EmailNotConfirmed);
     }
 
-    // It mustn't be a visitor
-    if (user.type === UserType.visitor) {
-      return forbidden(response, Error.LoginAsVisitor);
+    // It mustn't be an attendant
+    if (user.type === UserType.attendant) {
+      return forbidden(response, Error.LoginAsAttendant);
     }
 
     // Set the sentry user to identify the problem in case of 500

--- a/src/operations/carts.ts
+++ b/src/operations/carts.ts
@@ -84,12 +84,15 @@ export const refundCart = (cartId: string): Promise<Cart> =>
 export const forcePay = (user: prisma.User) => {
   let itemId;
 
-  if (user.type === UserType.player) {
-    itemId = 'ticket-player';
-  } else if (user.type === UserType.coach) {
-    itemId = 'ticket-coach';
-  } else {
-    throw new Error(`Can't pay for ${user.type}`);
+  switch (user.type) {
+    case UserType.player:
+    case UserType.coach:
+    case UserType.spectator:
+      itemId = `ticket-${user.type}`;
+      break;
+    default: {
+      throw new Error(`Can't pay for ${user.type}`);
+    }
   }
 
   return database.cart.create({

--- a/src/operations/log.ts
+++ b/src/operations/log.ts
@@ -2,17 +2,13 @@ import database from '../services/database';
 import nanoid from '../utils/nanoid';
 
 export const createLog = (method: string, path: string, userId: string, body: object | undefined) => {
-  const safeBody = {};
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const safeBody: any = {};
 
-  // Remove all the keys from the body container the word password to avoid logging plain text passwords
-  if (body) {
-    for (const [key, value] of Object.entries(body)) {
-      if (!key.toLowerCase().includes('password')) {
-        // @ts-ignore
-        safeBody[key] = value;
-      }
-    }
-  }
+  // Remove all the values of the keys containing the word password to avoid logging plain text passwords
+  if (body)
+    for (const [key, value] of Object.entries(body))
+      safeBody[key] = !key.toLowerCase().includes('password') ? value : '***';
 
   return database.log.create({
     data: {

--- a/src/operations/team.ts
+++ b/src/operations/team.ts
@@ -116,9 +116,9 @@ export const deleteTeam = (teamId: string) =>
   ]);
 
 export const askJoinTeam = async (teamId: string, userId: string, userType: UserType) => {
-  // We check the amount of coaches and visitor at that point (globally AND in the team)
+  // We check the amount of coaches at that point
   const teamCoachCount = await countCoaches(teamId);
-  if (teamCoachCount > teamMaxCoachCount)
+  if (teamCoachCount >= teamMaxCoachCount)
     throw Object.assign(new Error('Query cannot be executed: max count of coach reached already'), {
       code: 'API_COACH_MAX_TEAM',
     });

--- a/src/operations/team.ts
+++ b/src/operations/team.ts
@@ -2,7 +2,9 @@ import prisma, { TournamentId, UserType } from '@prisma/client';
 import database from '../services/database';
 import { PrimitiveUser, Team, User } from '../types';
 import nanoid from '../utils/nanoid';
-import { formatUser, userInclusions } from './user';
+import { countCoaches, formatUser, userInclusions } from './user';
+
+const teamMaxCoachCount = 2;
 
 const teamInclusions = {
   users: {
@@ -114,6 +116,14 @@ export const deleteTeam = (teamId: string) =>
   ]);
 
 export const askJoinTeam = async (teamId: string, userId: string, userType: UserType) => {
+  // We check the amount of coaches and visitor at that point (globally AND in the team)
+  const teamCoachCount = await countCoaches(teamId);
+  if (teamCoachCount > teamMaxCoachCount)
+    throw Object.assign(new Error('Query cannot be executed: max count of coach reached already'), {
+      code: 'API_COACH_MAX_TEAM',
+    });
+
+  // Then we create the join request when it is alright
   const updatedUser = await database.user.update({
     data: {
       askingTeam: {

--- a/src/operations/user.ts
+++ b/src/operations/user.ts
@@ -110,13 +110,19 @@ export const createUser = async (user: {
   });
 };
 
-export const updateUser = async (userId: string, username: string, newPassword: string): Promise<User> => {
+export const updateUser = async (
+  userId: string,
+  data: {
+    username: string;
+    newPassword: string;
+  },
+): Promise<User> => {
   const salt = await userOperations.genSalt(env.bcrypt.rounds);
-  const hashedPassword = await userOperations.hash(newPassword, salt);
+  const hashedPassword = data.newPassword ? await userOperations.hash(data.newPassword, salt) : undefined;
 
   const user = await database.user.update({
     data: {
-      username,
+      username: data.username,
       password: hashedPassword,
     },
     where: {

--- a/src/operations/user.ts
+++ b/src/operations/user.ts
@@ -153,6 +153,12 @@ export const updateAdminUser = async (
       discordId: updates.discordId,
       customMessage: updates.customMessage,
       age: updates.age,
+      team:
+        updates.type === UserType.spectator
+          ? {
+              disconnect: true,
+            }
+          : undefined,
     },
     where: { id: userId },
     include: userInclusions,

--- a/src/operations/user.ts
+++ b/src/operations/user.ts
@@ -23,7 +23,7 @@ export const formatUser = (user: PrimitiveUser): User => {
     throw new Error('Error just to make sure of something');
 
   const hasPaid = user.cartItems.some(
-    (cartItem) => cartItem.itemId === 'ticket-player' && cartItem.cart.transactionState === TransactionState.paid,
+    (cartItem) => cartItem.itemId === `ticket-${user.type}` && cartItem.cart.transactionState === TransactionState.paid,
   );
 
   return {
@@ -258,25 +258,23 @@ export const deleteUser = (id: string) => database.user.delete({ where: { id } }
  * @param teamId the id of the team to count coaches in
  * @returns the amount of coaches in the given team
  */
-export const countCoaches = (teamId?: string) =>
+export const countCoaches = (teamId: string) =>
   database.user.count({
     where: {
       AND: [
         {
           type: UserType.coach,
         },
-        teamId
-          ? {
-              OR: [
-                {
-                  teamId,
-                },
-                {
-                  askingTeamId: teamId,
-                },
-              ],
-            }
-          : undefined,
+        {
+          OR: [
+            {
+              teamId,
+            },
+            {
+              askingTeamId: teamId,
+            },
+          ],
+        },
       ],
     },
   });

--- a/src/operations/user.ts
+++ b/src/operations/user.ts
@@ -12,6 +12,8 @@ export const userInclusions = {
       cart: true,
     },
   },
+  attendant: true,
+  attended: true,
 };
 
 export const formatUser = (user: PrimitiveUser): User => {
@@ -153,14 +155,23 @@ export const updateAdminUser = async (
   return formatUser(user);
 };
 
-export const createAttendant = (firstname: string, lastname: string) =>
-  database.user.create({
+export const createAttendant = (referrerId: string, firstname: string, lastname: string) =>
+  database.user.update({
     data: {
-      id: nanoid(),
-      firstname,
-      lastname,
-      type: UserType.attendant,
+      attendant: {
+        create: {
+          id: nanoid(),
+          firstname,
+          lastname,
+          type: UserType.attendant,
+          age: UserAge.adult,
+        },
+      },
     },
+    where: {
+      id: referrerId,
+    },
+    include: userInclusions,
   });
 
 export const removeUserRegisterToken = (userId: string) =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import prisma, { TournamentId, TransactionState, UserType } from '@prisma/client';
+import prisma, { TournamentId, TransactionState, UserType, UserAge } from '@prisma/client';
 import { ErrorRequestHandler } from 'express';
 import Mail from 'nodemailer/lib/mailer';
 /**
@@ -93,10 +93,15 @@ export type PrimitiveUser = prisma.User & {
 
 export type User = PrimitiveUser & {
   hasPaid: boolean;
+  attendant?: Pick<User, 'firstname' | 'lastname' | 'id'> & {
+    age: typeof UserAge.adult;
+    type: typeof UserType.attendant;
+  };
+  attended?: User & {
+    age: typeof UserAge.child;
+  };
 };
 
-// DOCS : Update docs schema
-// UPDATE : Append existing attendant to the object
 export type UserWithTeam = User & {
   team: prisma.Team;
 };
@@ -179,7 +184,7 @@ export const enum Error {
   NotInTeam = "Vous n'êtes pas dans l'équipe",
   LoginAsAttendant = "Vous ne pouvez pas vous connecter en tant qu'accompagnateur",
   AlreadyAuthenticated = 'Vous êtes déjà identifié',
-  NotPlayerOrCoach = "L'utilisateur n'est pas un joueur ou un coach",
+  NotPlayerOrCoachOrSpectator = "L'utilisateur n'est ni un joueur, ni un coach, ni un spectateur",
   AlreadyPaid = 'Le joueur possède déjà une place',
   AlreadyErrored = 'Vous ne pouvez pas valider une transaction échouée',
   TeamLocked = "L'équipe est verrouillée",
@@ -195,6 +200,8 @@ export const enum Error {
   NotSameType = "Les deux utilisateurs n'ont pas le même type",
   BasketCannotBeNegative = 'Le total du panier ne peut pas être négatif',
   TeamMaxCoachReached = 'Une équipe ne peut pas avoir plus de deux coachs',
+  AttendantNotAllowed = "Un majeur ne peut pas avoir d'accompagnateur",
+  AttendantAlreadyRegistered = "Vous ne pouvez pas avoir plus d'un accompagnateur",
 
   // 404
   // The server can't find the requested resource

--- a/src/types.ts
+++ b/src/types.ts
@@ -202,6 +202,9 @@ export const enum Error {
   TeamMaxCoachReached = 'Une équipe ne peut pas avoir plus de deux coachs',
   AttendantNotAllowed = "Un majeur ne peut pas avoir d'accompagnateur",
   AttendantAlreadyRegistered = "Vous ne pouvez pas avoir plus d'un accompagnateur",
+  CannotSpectate = 'Vous devez quitter votre équipe pour devenir spectateur',
+  CannotUnSpectate = "Vous n'êtes pas spectateur",
+  NoSpectator = "Les spectateurs n'ont pas accès à cette ressource",
 
   // 404
   // The server can't find the requested resource
@@ -221,6 +224,7 @@ export const enum Error {
   EmailAlreadyExists = 'Cet email est déjà utilisé',
   UsernameAlreadyExists = "Ce nom d'utilisateur est déjà utilisé",
   TeamAlreadyExists = "Le nom de l'équipe existe déjà",
+  PlaceAlreadyAttributed = 'Cette place est déjà attribuée',
 
   // 410
   // indicates that access to the target resource is no longer available at the server.

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,8 @@ export type User = PrimitiveUser & {
   hasPaid: boolean;
 };
 
+// DOCS : Update docs schema
+// UPDATE : Append existing attendant to the object
 export type UserWithTeam = User & {
   team: prisma.Team;
 };
@@ -144,9 +146,9 @@ export type EtupayError = ErrorRequestHandler & {
 /**********/
 /** Misc **/
 /**********/
+
 export const enum Error {
   // More info on https://www.loggly.com/blog/http-status-code-diagram to know where to put an error
-
   // 400
   // Used when the request contains a bad syntax and makes the request unprocessable
   InvalidBody = 'Corps de la requête invalide',
@@ -175,7 +177,7 @@ export const enum Error {
   NotCaptain = "Vous devez être le capitaine de l'équipe pour modifier cette ressource",
   NotSelf = 'Vous ne pouvez pas modifier les information de cette personne',
   NotInTeam = "Vous n'êtes pas dans l'équipe",
-  LoginAsVisitor = 'Vous ne pouvez pas vous connecter en tant que visiteur',
+  LoginAsAttendant = "Vous ne pouvez pas vous connecter en tant qu'accompagnateur",
   AlreadyAuthenticated = 'Vous êtes déjà identifié',
   NotPlayerOrCoach = "L'utilisateur n'est pas un joueur ou un coach",
   AlreadyPaid = 'Le joueur possède déjà une place',
@@ -192,6 +194,7 @@ export const enum Error {
   CannotChangeType = 'Vous ne pouvez pas changer de type si vous avez payé',
   NotSameType = "Les deux utilisateurs n'ont pas le même type",
   BasketCannotBeNegative = 'Le total du panier ne peut pas être négatif',
+  TeamMaxCoachReached = 'Une équipe ne peut pas avoir plus de deux coachs',
 
   // 404
   // The server can't find the requested resource

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -39,6 +39,7 @@ const env = {
     port: loadIntEnv('API_PORT') || 3000,
     prefix: loadEnv('API_PREFIX') || '/',
     itemsPerPage: 50,
+    cartLifespan: loadIntEnv('API_CART_LIFESPAN') || 3600000,
   },
   front: {
     website: loadEnv('ARENA_WEBSITE') || 'https://arena.utt.fr',

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -11,6 +11,7 @@ export const filterUser = (user: User) =>
     'username',
     'firstname',
     'lastname',
+    'age',
     'email',
     'permissions',
     'place',

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -19,6 +19,9 @@ export const filterUser = (user: User) =>
     'discordId',
     'teamId',
     'askingTeamId',
+    'attendant.firstname',
+    'attendant.lastname',
+    'attendant.id',
   ]);
 
 export const filterUserWithTeam = (user: UserWithTeam) => {

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -1,5 +1,5 @@
 import Joi from 'joi';
-import { TournamentId, UserType } from '@prisma/client';
+import { TournamentId, UserAge, UserType } from '@prisma/client';
 import { Permission } from '../types';
 
 // Matches with LoL EUW summoner name
@@ -19,6 +19,7 @@ export const email = Joi.string().email();
 export const password = Joi.string().regex(passwordRegex);
 export const discordId = Joi.string();
 export const type = Joi.string().valid(...Object.keys(UserType));
+export const age = Joi.string().valid(...Object.keys(UserAge));
 export const place = Joi.string().regex(placeRegex);
 export const permission = Joi.string().valid(...Object.keys(Permission));
 export const stringBoolean = Joi.string().valid('true', 'false');

--- a/tests/admin/auth/login.test.ts
+++ b/tests/admin/auth/login.test.ts
@@ -36,13 +36,13 @@ describe('POST /admin/auth/login', () => {
       .expect(403, { error: Error.NoPermission });
   });
 
-  it('should error because the user is a visitor', async () => {
-    const visitor = await createFakeUser({ type: UserType.visitor });
+  it('should error because the user is an attendant', async () => {
+    const visitor = await createFakeUser({ type: UserType.attendant });
 
     await request(app)
       .post(`/admin/auth/login/${visitor.id}`)
       .set('Authorization', `Bearer ${adminToken}`)
-      .expect(403, { error: Error.LoginAsVisitor });
+      .expect(403, { error: Error.LoginAsAttendant });
   });
 
   it('should error because the user is not confirmed', async () => {

--- a/tests/admin/users/getUsers.test.ts
+++ b/tests/admin/users/getUsers.test.ts
@@ -83,6 +83,7 @@ describe('GET /admin/users', () => {
       askingTeamId: null,
       discordId: user.discordId,
       type: user.type,
+      age: user.age,
       username: user.username,
       hasPaid: false,
       customMessage: null,

--- a/tests/admin/users/updateUser.test.ts
+++ b/tests/admin/users/updateUser.test.ts
@@ -163,13 +163,12 @@ describe('PATCH /admin/users/:userId', () => {
       .expect(409, { error: Error.PlaceAlreadyAttributed }));
 
   it('should fail as the user has already paid and wants to change its type', async () => {
+    user = await userOperations.fetchUser(user.id);
     await forcePay(user);
-    const paidUser = await userOperations.fetchUser(user.id);
-    expect(paidUser.hasPaid).to.be.true;
     return request(app)
       .patch(`/admin/users/${user.id}`)
       .set('Authorization', `Bearer ${adminToken}`)
-      .send({ type: paidUser.type === UserType.player ? UserType.coach : UserType.player })
+      .send({ type: user.type === UserType.player ? UserType.coach : UserType.player })
       .expect(403, { error: Error.CannotChangeType });
   });
 });

--- a/tests/admin/users/updateUser.test.ts
+++ b/tests/admin/users/updateUser.test.ts
@@ -1,13 +1,14 @@
 import { expect } from 'chai';
 import request from 'supertest';
 import app from '../../../src/app';
-import { createFakeUser } from '../../utils';
+import { createFakeTeam, createFakeUser } from '../../utils';
 import database from '../../../src/services/database';
 import { Error, Permission, User } from '../../../src/types';
 import * as userOperations from '../../../src/operations/user';
 import { sandbox } from '../../setup';
 import { generateToken } from '../../../src/utils/users';
 import { forcePay } from '../../../src/operations/carts';
+import { UserType } from '.prisma/client';
 
 describe('PATCH /admin/users/:userId', () => {
   let user: User;
@@ -19,7 +20,7 @@ describe('PATCH /admin/users/:userId', () => {
     place: string;
     permissions: Permission[];
   } = {
-    type: 'player',
+    type: UserType.player,
     place: 'A23',
     permissions: [],
   };
@@ -35,6 +36,7 @@ describe('PATCH /admin/users/:userId', () => {
     await database.cartItem.deleteMany();
     await database.cart.deleteMany();
     await database.log.deleteMany();
+    await database.team.deleteMany();
     await database.user.deleteMany();
   });
 
@@ -64,12 +66,12 @@ describe('PATCH /admin/users/:userId', () => {
       .send(validBody)
       .expect(404, { error: Error.UserNotFound }));
 
-  it('should throw an internal server error', async () => {
+  it('should throw an internal server error', () => {
     // Fake the main function to throw
     sandbox.stub(userOperations, 'updateAdminUser').throws('Unexpected error');
 
     // Request to login
-    await request(app)
+    return request(app)
       .patch(`/admin/users/${user.id}`)
       .set('Authorization', `Bearer ${adminToken}`)
       .send(validBody)
@@ -77,32 +79,56 @@ describe('PATCH /admin/users/:userId', () => {
   });
 
   it('should update the user', async () => {
+    const team = await createFakeTeam();
+    const teamMember = team.players[0];
+
     const { body } = await request(app)
-      .patch(`/admin/users/${user.id}`)
+      .patch(`/admin/users/${teamMember.id}`)
       .set('Authorization', `Bearer ${adminToken}`)
       .send(validBody)
       .expect(200);
 
-    const updatedUser = await userOperations.fetchUser(user.id);
+    const updatedUser = await userOperations.fetchUser(teamMember.id);
 
     expect(body.type).to.be.equal(validBody.type);
     expect(body.place).to.be.equal(validBody.place);
+    expect(body.teamId).to.be.equal(team.id);
 
     expect(body.type).to.be.equal(updatedUser.type);
     expect(body.place).to.be.equal(updatedUser.place);
+    expect(body.teamId).to.be.equal(updatedUser.teamId);
+  });
+
+  it('should update the user and remove him from his team', async () => {
+    const team = await createFakeTeam({ members: 2 });
+    const teamMember = team.players.find((member) => member.id !== team.captainId);
+
+    const { body } = await request(app)
+      .patch(`/admin/users/${teamMember.id}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        type: UserType.spectator,
+      })
+      .expect(200);
+
+    const updatedUser = await userOperations.fetchUser(teamMember.id);
+
+    expect(body.type).to.be.equal(UserType.spectator);
+    expect(body.type).to.be.equal(updatedUser.type);
+    expect(body.teamId).to.be.equal(updatedUser.teamId);
   });
 
   it('should work if body is incomplete', async () => {
     const { body } = await request(app)
       .patch(`/admin/users/${user.id}`)
       .send({
-        type: 'player',
+        type: UserType.coach,
         permissions: [],
       })
       .set('Authorization', `Bearer ${adminToken}`)
       .expect(200);
 
-    expect(body.place).to.be.equal(validBody.place);
+    expect(body.type).to.be.equal(UserType.coach);
   });
 
   it('should be able to update discordId only', async () => {
@@ -129,12 +155,21 @@ describe('PATCH /admin/users/:userId', () => {
     expect(body.customMessage).to.be.equal('Autorisation parentale');
   });
 
-  it('should fail as the user has already paid and wants to change its type', async () => {
-    await forcePay(user);
-    await request(app)
+  it('should fail as the place is already attributed', () =>
+    request(app)
       .patch(`/admin/users/${user.id}`)
       .set('Authorization', `Bearer ${adminToken}`)
-      .send({ ...validBody, type: 'coach' })
+      .send({ place: validBody.place })
+      .expect(409, { error: Error.PlaceAlreadyAttributed }));
+
+  it('should fail as the user has already paid and wants to change its type', async () => {
+    await forcePay(user);
+    const paidUser = await userOperations.fetchUser(user.id);
+    expect(paidUser.hasPaid).to.be.true;
+    return request(app)
+      .patch(`/admin/users/${user.id}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ type: paidUser.type === UserType.player ? UserType.coach : UserType.player })
       .expect(403, { error: Error.CannotChangeType });
   });
 });

--- a/tests/auth/login.test.ts
+++ b/tests/auth/login.test.ts
@@ -76,10 +76,10 @@ describe('POST /auth/login', () => {
   });
 
   // This case should never happen
-  it('should error because the user is a visitor', async () => {
+  it('should error because the user is an attendant', async () => {
     const visitorEmail = 'bonjour@lol.fr';
     const visitorPassword = 'randomPass';
-    await createFakeUser({ type: UserType.visitor, email: visitorEmail, password: visitorPassword });
+    await createFakeUser({ type: UserType.attendant, email: visitorEmail, password: visitorPassword });
 
     await request(app)
       .post('/auth/login')
@@ -87,7 +87,7 @@ describe('POST /auth/login', () => {
         login: visitorEmail,
         password: visitorPassword,
       })
-      .expect(403, { error: Error.LoginAsVisitor });
+      .expect(403, { error: Error.LoginAsAttendant });
   });
 
   let authorizationToken = '';

--- a/tests/auth/register.test.ts
+++ b/tests/auth/register.test.ts
@@ -21,6 +21,7 @@ describe('POST /auth/register', () => {
     lastname: 'Doe',
     email: 'john.doe@test.com',
     password: 'jesuisthomas',
+    age: 'adult',
   };
 
   it('should get an error as the login is not allowed', async () => {
@@ -51,7 +52,7 @@ describe('POST /auth/register', () => {
       .post('/auth/register')
       .send({
         ...userData,
-        type: UserType.visitor,
+        type: UserType.attendant,
       })
       .expect(400, { error: Error.InvalidBody });
   });

--- a/tests/middlewares.test.ts
+++ b/tests/middlewares.test.ts
@@ -83,11 +83,14 @@ describe('Test middlewares', () => {
     });
 
     // This case should never happen
-    it('should error because the user is a visitor', async () => {
-      const user = await createFakeUser({ type: UserType.visitor });
+    it('should error because the user is a attendant', async () => {
+      const user = await createFakeUser({ type: UserType.attendant });
       const token = generateToken(user);
 
-      await request(app).get('/').set('Authorization', `Bearer ${token}`).expect(403, { error: Error.LoginAsVisitor });
+      await request(app)
+        .get('/')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(403, { error: Error.LoginAsAttendant });
     });
   });
 });

--- a/tests/services/email.test.ts
+++ b/tests/services/email.test.ts
@@ -86,7 +86,7 @@ describe('Tests the email utils', () => {
   it(`should generate a payment template`, async () => {
     // Create a fake user and add it in a random team
     const user = await createFakeUser();
-    const visitor = await createFakeUser({ type: UserType.visitor });
+    const spectator = await createFakeUser({ type: UserType.spectator });
     const coach = await createFakeUser({ type: UserType.coach });
 
     const items = await fetchAllItems();
@@ -101,7 +101,7 @@ describe('Tests the email utils', () => {
 
     const createdCart = await createCart(user.id, [
       { itemId: 'ticket-player', quantity: 1, forUserId: user.id },
-      { itemId: 'ticket-visitor', quantity: 1, forUserId: visitor.id },
+      { itemId: 'ticket-spectator', quantity: 1, forUserId: spectator.id },
       { itemId: 'ticket-coach', quantity: 1, forUserId: coach.id },
       ...supplementsCartItems,
     ]);

--- a/tests/teams/createTeam.test.ts
+++ b/tests/teams/createTeam.test.ts
@@ -55,6 +55,17 @@ describe('POST /teams', () => {
       .expect(403, { error: Error.AlreadyInTeam });
   });
 
+  it('should fail because the user is a spectator', async () => {
+    const spectator = await createFakeUser({ type: UserType.spectator });
+    const spectatorToken = generateToken(spectator);
+
+    return request(app)
+      .post('/teams')
+      .send(teamBody)
+      .set('Authorization', `Bearer ${spectatorToken}`)
+      .expect(403, { error: Error.NoSpectator });
+  });
+
   it('should fail because the body is incorrect', () =>
     request(app)
       .post('/teams')

--- a/tests/teams/createTeamRequest.test.ts
+++ b/tests/teams/createTeamRequest.test.ts
@@ -54,6 +54,17 @@ describe('POST /teams/:teamId/join-requests', () => {
       .expect(403, { error: Error.AlreadyInTeam });
   });
 
+  it('should fail because the user is a spectator', async () => {
+    const spectator = await createFakeUser({ type: UserType.spectator });
+    const spectatorToken = generateToken(spectator);
+
+    return request(app)
+      .post(`/teams/${team.id}/join-requests`)
+      .send({ userType: UserType.player })
+      .set('Authorization', `Bearer ${spectatorToken}`)
+      .expect(403, { error: Error.NoSpectator });
+  });
+
   it('should fail with an internal server error', async () => {
     sandbox.stub(teamOperations, 'askJoinTeam').throws('Unexpected error');
     await request(app)

--- a/tests/users/createCart.test.ts
+++ b/tests/users/createCart.test.ts
@@ -5,6 +5,7 @@ import app from '../../src/app';
 import { sandbox } from '../setup';
 import * as userOperations from '../../src/operations/user';
 import * as itemOperations from '../../src/operations/item';
+import * as cartOperations from '../../src/operations/carts';
 import database from '../../src/services/database';
 import { Error, User, Team } from '../../src/types';
 import { createFakeUser, createFakeTeam } from '../utils';
@@ -31,7 +32,6 @@ describe('POST /users/current/carts', () => {
   let annoyingUserWithSwitchDiscount: User;
   let annoyingTokenWithSwitchDiscount: string;
 
-  // TESTS : Remove visitors property (update to attendant)
   const validCart: PayBody = {
     tickets: {
       userIds: [],
@@ -292,7 +292,7 @@ describe('POST /users/current/carts', () => {
   });
 
   it('should fail with an internal server error (inner try/catch)', () => {
-    sandbox.stub(userOperations, 'createAttendant').throws('Unexpected error');
+    sandbox.stub(cartOperations, 'createCart').throws('Unexpected error');
 
     return request(app)
       .post(`/users/current/carts`)
@@ -386,7 +386,7 @@ describe('POST /users/current/carts', () => {
     expect(body.url).to.startWith(env.etupay.url);
 
     // player place - 1 * discount-ssbu
-    expect(body.price).to.be.equal(1500 - 300);
+    expect(body.price).to.be.equal(2000 - 300);
 
     expect(carts).to.have.lengthOf(1);
     expect(cartItems).to.have.lengthOf(2);

--- a/tests/users/createCart.test.ts
+++ b/tests/users/createCart.test.ts
@@ -382,7 +382,7 @@ describe('POST /users/current/carts', () => {
 
     expect(body.url).to.startWith(env.etupay.url);
 
-    // player place + player reduced price + coach place + (~~attendant place~~) + 4 * ethernet-7
+    // player place + player reduced price + coach place + attendant place + 4 * ethernet-7
     expect(body.price).to.be.equal(2000 + 1500 + 1200 + 1200 + 4 * 1000);
 
     expect(carts).to.have.lengthOf(1);

--- a/tests/users/createSpectator.test.ts
+++ b/tests/users/createSpectator.test.ts
@@ -1,0 +1,53 @@
+import { UserType } from '@prisma/client';
+import request from 'supertest';
+import { expect } from 'chai';
+import { generateToken } from '../../src/utils/users';
+import { createFakeUser } from '../utils';
+import { Error, User } from '../../src/types';
+import database from '../../src/services/database';
+import app from '../../src/app';
+import { updateAdminUser } from '../../src/operations/user';
+
+describe('POST /users/current/spectate', () => {
+  let user: User;
+  let token: string;
+
+  before(async () => {
+    user = await createFakeUser();
+    token = generateToken(user);
+  });
+
+  after(async () => {
+    // Delete the user created
+    await database.log.deleteMany();
+    await database.user.deleteMany();
+  });
+
+  it('should fail as user is not authenticated', () =>
+    request(app).post(`/users/current/spectate`).send().expect(401, { error: Error.Unauthenticated }));
+
+  it('should fail as user has already a type', () =>
+    request(app)
+      .post(`/users/current/spectate`)
+      .send()
+      .set('Authorization', `Bearer ${token}`)
+      .expect(403, { error: Error.CannotSpectate }));
+
+  it('should return the new spectator user', async () => {
+    const updatedUser = await updateAdminUser(user.id, { type: null });
+    const response = await request(app)
+      .post(`/users/current/spectate`)
+      .send()
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    return expect({
+      ...response.body,
+      updatedAt: null,
+    }).to.been.deep.equal({
+      ...updatedUser,
+      type: UserType.spectator,
+      updatedAt: null,
+      createdAt: updatedUser.createdAt.toISOString(),
+    });
+  });
+});

--- a/tests/users/deleteSpectator.test.ts
+++ b/tests/users/deleteSpectator.test.ts
@@ -1,0 +1,60 @@
+import { UserType } from '@prisma/client';
+import { expect } from 'chai';
+import request from 'supertest';
+import app from '../../src/app';
+import { updateAdminUser } from '../../src/operations/user';
+import database from '../../src/services/database';
+import { Error, User } from '../../src/types';
+import { generateToken } from '../../src/utils/users';
+import { createFakeUser } from '../utils';
+
+describe('DELETE /users/current/spectate', () => {
+  let user: User;
+  let token: string;
+
+  before(async () => {
+    user = await createFakeUser();
+    token = generateToken(user);
+  });
+
+  after(async () => {
+    // Delete the user created
+    await database.log.deleteMany();
+    await database.user.deleteMany();
+  });
+
+  it('should fail as user is not authenticated', () =>
+    request(app).delete(`/users/current/spectate`).send().expect(401, { error: Error.Unauthenticated }));
+
+  it('should fail as user has an invalid type', () =>
+    request(app)
+      .delete(`/users/current/spectate`)
+      .send()
+      .set('Authorization', `Bearer ${token}`)
+      .expect(403, { error: Error.CannotUnSpectate }));
+
+  it('should return the new spectator user', async () => {
+    const updatedUser = await updateAdminUser(user.id, { type: UserType.spectator });
+    const response = await request(app)
+      .delete(`/users/current/spectate`)
+      .send()
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    return expect({
+      ...response.body,
+      updatedAt: null,
+    }).to.been.deep.equal({
+      ...updatedUser,
+      type: null,
+      updatedAt: null,
+      createdAt: updatedUser.createdAt.toISOString(),
+    });
+  });
+
+  it('should fail as user has no type', () =>
+    request(app)
+      .delete(`/users/current/spectate`)
+      .send()
+      .set('Authorization', `Bearer ${token}`)
+      .expect(403, { error: Error.CannotUnSpectate }));
+});

--- a/tests/users/updateUser.test.ts
+++ b/tests/users/updateUser.test.ts
@@ -98,6 +98,8 @@ describe('PATCH /users/current', () => {
       id: log.id,
       createdAt: log.createdAt,
     });
+
+    return database.log.deleteMany();
   });
 
   it('should update the user', async () => {
@@ -113,7 +115,7 @@ describe('PATCH /users/current', () => {
     expect(body.updatedAt).to.be.undefined;
 
     const logs = await database.log.findMany();
-    expect(logs).to.have.lengthOf(2);
+    expect(logs).to.have.lengthOf(1);
 
     const [log] = logs;
 

--- a/tests/users/updateUser.test.ts
+++ b/tests/users/updateUser.test.ts
@@ -8,7 +8,7 @@ import { Error, User } from '../../src/types';
 import { createFakeUser } from '../utils';
 import { generateToken } from '../../src/utils/users';
 
-describe('PUT /users/current', () => {
+describe('PATCH /users/current', () => {
   let user: User;
   let token: string;
 
@@ -33,26 +33,26 @@ describe('PUT /users/current', () => {
 
   it('shoud fail because the body is empty', async () => {
     await request(app)
-      .put(`/users/current`)
+      .patch(`/users/current`)
       .set('Authorization', `Bearer ${token}`)
       .expect(400, { error: Error.InvalidBody });
   });
 
   it('shoud fail because the password is missing', async () => {
     await request(app)
-      .put(`/users/current`)
+      .patch(`/users/current`)
       .set('Authorization', `Bearer ${token}`)
       .send({ username: 'bonjour', newPassowrd: 'Bonjour123456' })
       .expect(400, { error: Error.InvalidBody });
   });
 
   it('should fail because the user is not authenticated', async () => {
-    await request(app).put(`/users/current`).send(validBody).expect(401, { error: Error.Unauthenticated });
+    await request(app).patch(`/users/current`).send(validBody).expect(401, { error: Error.Unauthenticated });
   });
 
   it('should fail as the password is invalid', async () => {
     await request(app)
-      .put(`/users/current`)
+      .patch(`/users/current`)
       .set('Authorization', `Bearer ${token}`)
       .send({ ...validBody, password: 'wrongPassword' })
       .expect(401, { error: Error.InvalidCredentials });
@@ -62,15 +62,47 @@ describe('PUT /users/current', () => {
     sandbox.stub(userOperations, 'updateUser').throws('Unexpected error');
 
     await request(app)
-      .put(`/users/current`)
+      .patch(`/users/current`)
       .set('Authorization', `Bearer ${token}`)
       .send(validBody)
       .expect(500, { error: Error.InternalServerError });
   });
 
+  it('should update the user (username only)', async () => {
+    const username = 'tartempiondu10';
+    const { body } = await request(app)
+      .patch(`/users/current`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        username,
+        password: validBody.password,
+      })
+      .expect(200);
+
+    expect(body.username).to.be.equal(username);
+
+    // Check if the object was filtered
+    expect(body.updatedAt).to.be.undefined;
+
+    const logs = await database.log.findMany();
+    expect(logs).to.have.lengthOf(1);
+
+    const [log] = logs;
+
+    // Check if the log is correct and doesn't include the password values
+    expect(log).to.deep.equal({
+      path: `/users/current`,
+      body: { username, password: '***' },
+      method: 'PATCH',
+      userId: body.id,
+      id: log.id,
+      createdAt: log.createdAt,
+    });
+  });
+
   it('should update the user', async () => {
     const { body } = await request(app)
-      .put(`/users/current`)
+      .patch(`/users/current`)
       .set('Authorization', `Bearer ${token}`)
       .send(validBody)
       .expect(200);
@@ -81,15 +113,19 @@ describe('PUT /users/current', () => {
     expect(body.updatedAt).to.be.undefined;
 
     const logs = await database.log.findMany();
-    expect(logs).to.have.lengthOf(1);
+    expect(logs).to.have.lengthOf(2);
 
     const [log] = logs;
 
-    // Check if the log is correct and doesn't include the password fields
+    // Check if the log is correct and doesn't include the password values
     expect(log).to.deep.equal({
       path: `/users/current`,
-      body: { username: body.username },
-      method: 'PUT',
+      body: {
+        username: body.username,
+        password: '***',
+        newPassword: '***',
+      },
+      method: 'PATCH',
       userId: body.id,
       id: log.id,
       createdAt: log.createdAt,

--- a/tests/users/updateUser.test.ts
+++ b/tests/users/updateUser.test.ts
@@ -102,6 +102,23 @@ describe('PATCH /users/current', () => {
     return database.log.deleteMany();
   });
 
+  it('should fail as username is already in use', async () => {
+    const username = 'tartempiondu10';
+    const password = 'whatARandomPassword';
+
+    const otherUser = await createFakeUser({ password });
+    const userToken = generateToken(otherUser);
+
+    return request(app)
+      .patch(`/users/current`)
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({
+        username,
+        password,
+      })
+      .expect(409, { error: Error.UsernameAlreadyExists });
+  });
+
   it('should update the user', async () => {
     const { body } = await request(app)
       .patch(`/users/current`)

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,5 +1,5 @@
 import faker from 'faker';
-import prisma, { TournamentId, UserType } from '@prisma/client';
+import prisma, { TournamentId, UserAge, UserType } from '@prisma/client';
 import { createUser, fetchUser, removeUserRegisterToken, setPermissions } from '../src/operations/user';
 import { Permission, User } from '../src/types';
 import { createTeam, fetchTeam, joinTeam, lockTeam } from '../src/operations/team';
@@ -25,6 +25,7 @@ export const createFakeUser = async ({
   discordId = `${Math.floor(Date.now() * (1 + Math.random()))}`,
   permission,
   customMessage,
+  age = UserAge.adult,
 }: {
   username?: string;
   firstname?: string;
@@ -37,6 +38,7 @@ export const createFakeUser = async ({
   discordId?: string;
   permission?: Permission;
   customMessage?: string;
+  age?: UserAge;
 } = {}): Promise<User> => {
   const user: prisma.User = await createUser({
     username,
@@ -47,6 +49,7 @@ export const createFakeUser = async ({
     discordId,
     type,
     customMessage,
+    age,
   });
   logger.verbose(`Created user ${user.username}`);
 


### PR DESCRIPTION
## Objectif principal
Implémentation des UserTypes `attendant` (accompagnateur) et `spectator` (spectateur)

**Attention: changements conséquents dans la base de données. Il faudra très probablement drop la base de données puis exécuter `yarn prisma db push`. Pensez donc bien à exporter les données que vous souhaitez conserver.**

## Devenir spectateur:
Il faut ne pas avoir `créé/rejoint/envoyé une requête pour rejoindre` une team (ou l'avoir supprimée/quittée/annulée).
Utiliser la route `POST /users/current/spectate` pour devenir spectateur, `DELETE /users/current/spectate` pour ne plus être spectateur. (sous certaines conditions, dont le fait de ne pas avoir acheté son billet).

**Devenir spectateur n'implique PAS que l'utilisateur pourra obtenir un billet spectateur !** La limitation est réalisée sur l'achat des billets. Il peut être intéressant d'en informer l'utilisateur ou de coder une réservation temporaire du ticket.

## Autres changements
| Route (ou domaine d'application) | Changements |
| :-: | - |
| PATCH /admin/users/{userId} | Renvoie une erreur 409 si la place que l'admin essaie de donner au joueur est déjà attribuée. Si l'utilisateur est mis à jour vers la type `spectator`, il est exclu de son équipe automatiquement. |
| POST /teams/{teamId}/join-requests | Renvoie une erreur 403 si l'utilisateur essaie de rejoindre en tant que coach et que la limite a été atteinte dans l'équipe. Renvoie également une erreur 403 si l'utilisateur est un spectateur. |
| POST /teams | Renvoie une erreur 403 si l'utilisateur est un spectateur. |
| POST /users/current/carts | Le paramètre `visitors` a été renommé `attendant` et n'est plus une liste. Il est désormais également optionnel. Les utilisateurs majeurs qui remplissent les champ `attendant` auront une 403, comme les mineurs qui essaieraient d'ajouter plusieurs accompagnateurs. La billeterie fait maintenant la différence entre un article illimité et un article écoulé. |
| PATCH /users/current | Méthode modifiée (anciennement `PUT`). Les paramètres `username` et `newPassword` sont désormais facultatifs. **Le champ `password` est cependant toujours obligatoire !** Renvoie désormais une erreur 409 si le nom d'utilisateur est déjà pris. |
| POST /auth/register | Nécessite un nouveau paramètre: `age` qui vaut soit `child`, soit `adult` |
| Tickets | Mise à jour du seed.sql avec les nouveaux tickets |
| Logging | Les champs contenant 'password' sont désormais ajoutés au log avec la valeur `"***"`. Ce changement a été réalisé pour donner une utilité au log de `PATCH /users/current` où un utilisateur modifierait uniquement son mot de passe. |