### PR TITLE
draft(validate): backend account validation

### DIFF
--- a/src/services/email/serializer.ts
+++ b/src/services/email/serializer.ts
@@ -129,7 +129,7 @@ export const generateValidationEmail = (user: User) =>
           "On sait bien que c'est pénible mais on doit vérifier que ton adresse email fonctionne bien (sinon tu ne pourras pas recevoir tes billets&nbsp;!).",
           {
             name: 'Confirme ton adresse email',
-            location: `${env.front.website}/?action=${ActionFeedback.VALIDATE}&state=${user.registerToken}`,
+            location: `${env.front.website}/api/auth/validate/${user.registerToken}`,
           },
         ],
       },

--- a/src/utils/responses.ts
+++ b/src/utils/responses.ts
@@ -23,6 +23,9 @@ const respondError = (response: Response, error: Error, code: number) => {
   return response.status(code).json({ error }).end();
 };
 
+// Sends a 302 http response code with its redirection header
+export const redirect = (response: Response, url: string): void => response.status(302).set({ Location: url }).end();
+
 export const badRequest = (response: Response, error: Error): void => respondError(response, error, 400);
 
 export const unauthenticated = (response: Response, error?: Error): void =>

--- a/tests/auth/validate.test.ts
+++ b/tests/auth/validate.test.ts
@@ -3,10 +3,11 @@ import request from 'supertest';
 import app from '../../src/app';
 import database from '../../src/services/database';
 import * as userOperations from '../../src/operations/user';
-import { Error } from '../../src/types';
+import { ActionFeedback, Error } from '../../src/types';
 import { setLoginAllowed } from '../../src/operations/settings';
 import { sandbox } from '../setup';
 import { createFakeUser } from '../utils';
+import env from '../../src/utils/env';
 
 describe('POST /auth/validate/{token}', () => {
   const password = 'yolo59';
@@ -28,20 +29,27 @@ describe('POST /auth/validate/{token}', () => {
     await setLoginAllowed(true);
   });
 
-  it('should not accept wrong token', async () => {
-    await request(app).post('/auth/validate/wrongtoken').expect(400, { error: Error.InvalidParameters });
-  });
+  it('should not accept wrong token', () =>
+    request(app)
+      .post('/auth/validate/wrongtoken')
+      .expect(302)
+      .expect('Location', `${env.front.website}/?action=${ActionFeedback.VALIDATE}&state=1`));
 
-  it('should not accept unknown token', async () => {
-    await request(app).post('/auth/validate/A1B2C3').expect(400, { error: Error.InvalidParameters });
-  });
+  it('should not accept unknown token', () =>
+    request(app)
+      .post('/auth/validate/A1B2C3')
+      .expect(302)
+      .expect('Location', `${env.front.website}/?action=${ActionFeedback.VALIDATE}&state=1`));
 
-  it('should throw an internal server error', async () => {
+  it('should throw an internal server error', () => {
     // Fake the main function to throw
     sandbox.stub(userOperations, 'removeUserRegisterToken').throws('Unexpected error');
 
     // Request to validate the user
-    await request(app).post(`/auth/validate/${user.registerToken}`).expect(500, { error: Error.InternalServerError });
+    return request(app)
+      .post(`/auth/validate/${user.registerToken}`)
+      .expect(302)
+      .expect('Location', `${env.front.website}/?action=${ActionFeedback.VALIDATE}&state=2`);
   });
 
   it('should not log in as the account is not validated', async () => {
@@ -54,7 +62,9 @@ describe('POST /auth/validate/{token}', () => {
       .expect(403, { error: Error.EmailNotConfirmed });
   });
 
-  it('should validate the user', async () => {
-    await request(app).post(`/auth/validate/${user.registerToken}`).expect(200);
-  });
+  it('should validate the user', () =>
+    request(app)
+      .post(`/auth/validate/${user.registerToken}`)
+      .expect(302)
+      .expect('Location', `${env.front.website}/?action=${ActionFeedback.VALIDATE}&state=0`));
 });


### PR DESCRIPTION
Avec cette PR, la validation d'un compte se ferait avec une requête directement sur l'api.

La validation renverrait alors l'utilisateur sur un lien en `?action=validate&state={statusCode}` prenant les valeurs comme suit:
| statusCode | Signification |
| :-: | - |
| 0 | Le compte a été validé |
| 1 | Token invalide |
| 2 | Erreur inconnue |

Cependant ce changement supprime la connexion auto qui suit la validation du compte. L'utilisateur doit se reconnecter après la validation *(et cela ne change pas énormément niveau front vu qu'il n'y a qu'une requête à faire pour se connecter automatiquement et que le toast est affiché dans tous les cas)*.

Bref donnez votre avis :wink: