### PR TITLE
fix(misc): fix coach limit blocking new players in team

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,13 +24,9 @@ DATABASE_URL=mysql://root:root@localhost/arena
 # Used in mail templates
 ARENA_WEBSITE=http://localhost:8080
 
-# SMTP server configuration
-#     You can use Nodemailer App (https://nodemailer.com/app/) if you are not at the UTT
-#     Just copy the HOST, PORT, USER and PASSWORD given by Nodemailer App
-MAIL_HOST=smtp://smtp.utt.fr
-MAIL_PORT=25
-MAIL_USER=
-MAIL_PASSWORD=
+# SMTP server address (smtp://user:password@host(:port)?)
+# You can use Nodemailer App (https://nodemailer.com/app/) if you are not at the UTT
+SMTP_URI=smtp://smtp.utt.fr:25/?pool=true&maxConnections=1
 
 # Used to give a discount on tickets
 PARTNER_MAILS=utt.fr,utc.fr,utbm.fr

--- a/docs/doc_api/discord.md
+++ b/docs/doc_api/discord.md
@@ -4,8 +4,6 @@
 
 Synchronisation unidirectionnelle du site vers discord.
 
-A l'inscription, on demande le userTag, on fetch l'id dicord correspondant que l'on stocke dans la DB. En cas de besoin, on fetch le tag en fonction de l'id car l'id est permanant tandis que le tag peut changer. Le tag n'est pas souvent utilisé donc pas de souci pour faire un call à l'API de Discord. Pas d'update du userTag permis.
-
 A la création d'une équipe, on crée un rôle et un channel textuel, et un channel vocal du nom `tournoi-equipe`. Exemple `lol-les-best`. A determiner ce que l'on stocke dans la DB dans la table `teams`. (ID du rôle et du channel ?)
 
 Pour chaque tournoi, on a un channel textuel et un rôle. Les ID du rôle et du channel sont stockés en DB dans la table `tournaments`.

--- a/docs/doc_api/fake.md
+++ b/docs/doc_api/fake.md
@@ -1,5 +1,5 @@
 # Données de test
 
-On peut générer des données de test avec la commande `yarn test`. Cette commande est idempotente et va créer un nombre variés d'équipe et d'utilisateurs différents. Cette commande n'est pas executable en production pour des raisons évidentes de sécurité.
+On peut générer des données de test avec la commande `yarn fake`. Cette commande est idempotente et va créer un nombre variés d'équipe et d'utilisateurs différents. Cette commande n'est pas executable en production pour des raisons évidentes de sécurité.
 
 On peut se connecter sur chacun des utilisateurs car ils ont le même mot de passe : `uttarena`.

--- a/src/operations/team.ts
+++ b/src/operations/team.ts
@@ -118,7 +118,7 @@ export const deleteTeam = (teamId: string) =>
 export const askJoinTeam = async (teamId: string, userId: string, userType: UserType) => {
   // We check the amount of coaches at that point
   const teamCoachCount = await countCoaches(teamId);
-  if (teamCoachCount >= teamMaxCoachCount)
+  if (userType === UserType.coach && teamCoachCount >= teamMaxCoachCount)
     throw Object.assign(new Error('Query cannot be executed: max count of coach reached already'), {
       code: 'API_COACH_MAX_TEAM',
     });

--- a/src/services/email/components.ts
+++ b/src/services/email/components.ts
@@ -51,7 +51,7 @@ const inflateButtonWrapper = (item: Component.Button | Component.Button[]) =>
 
 const inflateTable = (item: Component.Table) => {
   const properties = Object.keys(item.items[0] ?? {});
-  if (properties.length === 0) return '';
+  if (properties.length === 0 || item.items.length < 2) return '';
   return `${
     item.name
       ? `<tr><td style="font-size:18px;color:${style.title.color};font-family:${style.title.font};padding:8px 0">${item.name}</td></tr>`

--- a/src/services/email/index.ts
+++ b/src/services/email/index.ts
@@ -9,21 +9,7 @@ import type { SerializedMail } from './types';
 
 export type { Component, Mail, SerializedMail } from './types';
 
-export const transporter = nodemailer.createTransport({
-  host: env.email.host,
-  port: env.email.port,
-  auth: {
-    user: env.email.user,
-    pass: env.email.password,
-  },
-  pool: true,
-  secure: false,
-  maxConnections: 1,
-  tls: {
-    // Rejects TLS errors only if we are not in test environment. (Rejects due to self signed certificate)
-    rejectUnauthorized: !env.test,
-  },
-});
+export const transporter = nodemailer.createTransport(env.email.uri);
 
 /**
  * Sends a mail (using the smtp server).

--- a/tests/services/email.test.ts
+++ b/tests/services/email.test.ts
@@ -67,7 +67,7 @@ describe('Tests the email utils', () => {
       },
     });
 
-    server.listen(env.email.port);
+    server.listen(env.email.uri.match(/:(\d+)/)[1]);
 
     await sendEmail(
       {
@@ -149,9 +149,24 @@ describe('Tests the email utils', () => {
             {
               test: 'This is a test',
             },
+            {
+              test: 'A random row',
+            },
           ],
         }),
       ).to.be.match(/^<tr><td></);
+    });
+
+    it('should not generate table when empty', () => {
+      expect(
+        inflate({
+          items: [
+            {
+              test: 'This is a test',
+            },
+          ],
+        }),
+      ).to.be.equal('');
     });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Correction de bugs:
- identifiants smtp dans une uri
- les tableaux vides ne sont plus générés dans les mails
- plus jamais de `redirect_uri` invalide pendant les tests d'oauth en localhost