### PR TITLE
fix(explicited-errors): translated empty login's error

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -179,6 +179,7 @@ export const enum Error {
   NoQRCode = "Le QR code n'existe pas",
 
   InvalidCart = 'Le contenu de la commande est invalide',
+  EmptyLogin = "Le nom d'utilisateur ne peut pas être vide",
 
   // 401
   // The user credentials were refused or not provided

--- a/tests/auth/login.test.ts
+++ b/tests/auth/login.test.ts
@@ -75,6 +75,15 @@ describe('POST /auth/login', () => {
       .expect(401, { error: Error.InvalidCredentials });
   });
 
+  it('should return an error as the login is empty', async () => {
+    await request(app)
+      .post('/auth/login')
+      .send({
+        password: user.password,
+      })
+      .expect(400, { error: Error.EmptyLogin });
+  });
+
   // This case should never happen
   it('should error because the user is an attendant', async () => {
     const visitorEmail = 'bonjour@lol.fr';


### PR DESCRIPTION
- L'erreur '"login" is not allowed to be empty' est maintenant en français
- ajout de l'erreur dans les types
- ajout du test correspondant