### PR TITLE
feat(admin): output of GET /admin/users is sorted

### DIFF
--- a/src/operations/user.ts
+++ b/src/operations/user.ts
@@ -124,6 +124,30 @@ export const fetchUsers = async (
       },
       skip: page * env.api.itemsPerPage,
       take: env.api.itemsPerPage,
+      orderBy: [
+        // Users not in a team will be returned before because NULL is considered as
+        // inferior to any other value
+        // In sql, this can be done using `CASE` but prisma doesn't support it for now
+        // cf. https://github.com/prisma/prisma/issues/4368 (that states postgresql syntax)
+        {
+          team: {
+            tournamentId: 'asc',
+          },
+        },
+        {
+          team: {
+            createdAt: 'asc',
+          },
+        },
+        {
+          team: {
+            id: 'asc',
+          },
+        },
+        {
+          type: 'asc',
+        },
+      ],
     }),
     database.user.count(filter),
   ]);


### PR DESCRIPTION
Ordre du tri:
`User#team#tournamentId` puis `User#team#createdAt` puis `User#team#id` et enfin `User#type`

_Note: les utilisateurs sans team seront renvoyés au début de la liste parce que prisma ne supporte pas bien la gestion des `NULL` dans les `ORDER BY`..._