### PR TITLE
fix(mails): added highlight route body, fix docs, more checks

### DIFF
--- a/src/controllers/admin/emails/getMails.ts
+++ b/src/controllers/admin/emails/getMails.ts
@@ -43,6 +43,8 @@ export default [
           }),
           subject: log.body.subject,
           content: log.body.content,
+          highlight: log.body.highlight,
+          reason: log.body.reason,
           tournamentId: log.body.tournamentId,
           locked: log.body.locked,
           sentAt: log.createdAt,

--- a/src/controllers/admin/openapi.yml
+++ b/src/controllers/admin/openapi.yml
@@ -109,7 +109,11 @@
             $ref: '#/components/schemas/MailQuery'
     responses:
       201:
-        description: Le mail a été envoyé avec succès
+        description: |-
+          Le mail a été envoyé. Plus de détails sur le nombre de messages envoyés, le nombre de messages mal formattés
+          (à cause d'erreurs spécifiques à une info utilisateur par exemple) et le nombre de messages non envoyés à cause
+          d'erreurs inconnues (très probablement erreurs réseau / adresses mail invalides)<br/>
+          **Les utilisateurs dont l'adresse email n'a pas été vérifiée ne recevront pas le mail**
         content:
           application/json:
             schema:
@@ -127,6 +131,112 @@
         $ref: '#/components/responses/401Unauthenticated'
       403:
         $ref: '#/components/responses/403Unauthorized'
+
+/admin/logs:
+  get:
+    summary: Récupère les actions effectués par les utilisateurs
+    description: Récupère les actions effectués par les utilisateurs.<br/>
+      **Permission 'admin' requise.**
+    tags:
+      - Admin
+    security:
+      - BearerAuth: []
+    parameters:
+      - in: query
+        name: userId
+        schema:
+          type: string
+      - in: query
+        name: teamId
+        schema:
+          type: string
+      - in: query
+        name: page
+        description: '(Pagination) Indice de la page'
+        schema:
+          type: integer
+          minimum: 0
+        required: true
+
+    responses:
+      200:
+        description: Un tableau de logs<br/>
+          **Permission 'admin' requise.**
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                logs:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Log'
+                pageIndex:
+                  type: number
+                  example: 1
+                pageCount:
+                  type: number
+                  example: 5
+                  description: Le nombre de pages disponibles
+                count:
+                  type: number
+                  example: 128
+                  description: Le nombre d'entrées correspondantes
+      400:
+        $ref: '#/components/responses/400Errored'
+      401:
+        $ref: '#/components/responses/401Unauthenticated'
+      403:
+        $ref: '#/components/responses/403Unauthorized'
+      404:
+        $ref: '#/components/responses/404UserNotFound'
+
+/admin/scan/:
+  post:
+    summary: Scanne le billet d'un utilisateur
+    description: Renvoie les informations de l'utilisateur.<br/>
+      **Permission 'entry' ou 'admin' requise.**<br/>
+      *Le billet ne doit pas avoir été déjà scanné.*
+      *Le billet est passé dans le body et non dans les paramètres car il est chiffré en base64 et peut contenir des slashs*
+    tags:
+      - Admin
+    security:
+      - BearerAuth: []
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              qrcode:
+                type: string
+                description: Contenu du QR code présent sur le billet chiffré
+              userId:
+                type: string
+                description: Peut remplacer le QR code si la lecture est trop longue/compliquée.
+                  Cette propriété ne peut pas être envoyée en même temps que `qrcode`
+    responses:
+      200:
+        description: Renvoie les informations de l'utilisateur et son équipe
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserWithTeamAndMessageAndTournamentInfo'
+      400:
+        $ref: '#/components/responses/400Errored'
+      401:
+        $ref: '#/components/responses/401Unauthenticated'
+      403:
+        $ref: '#/components/responses/403Unauthorized'
+      404:
+        description: Aucun utilisateur n'est associé à ce QR code
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Error'
+            example:
+              error: Aucun utilisateur n'est associé à ce QR code
 
 /admin/users:
   get:
@@ -338,65 +448,6 @@
       404:
         $ref: '#/components/responses/404UserNotFound'
 
-/admin/logs:
-  get:
-    summary: Récupère les actions effectués par les utilisateurs
-    description: Récupère les actions effectués par les utilisateurs.<br/>
-      **Permission 'admin' requise.**
-    tags:
-      - Admin
-    security:
-      - BearerAuth: []
-    parameters:
-      - in: query
-        name: userId
-        schema:
-          type: string
-      - in: query
-        name: teamId
-        schema:
-          type: string
-      - in: query
-        name: page
-        description: '(Pagination) Indice de la page'
-        schema:
-          type: integer
-          minimum: 0
-        required: true
-
-    responses:
-      200:
-        description: Un tableau de logs<br/>
-          **Permission 'admin' requise.**
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                logs:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/Log'
-                pageIndex:
-                  type: number
-                  example: 1
-                pageCount:
-                  type: number
-                  example: 5
-                  description: Le nombre de pages disponibles
-                count:
-                  type: number
-                  example: 128
-                  description: Le nombre d'entrées correspondantes
-      400:
-        $ref: '#/components/responses/400Errored'
-      401:
-        $ref: '#/components/responses/401Unauthenticated'
-      403:
-        $ref: '#/components/responses/403Unauthorized'
-      404:
-        $ref: '#/components/responses/404UserNotFound'
-
 /admin/users/{userId}/force-pay:
   post:
     summary: Valide le paiement d'un utilisateur
@@ -495,50 +546,3 @@
         $ref: '#/components/responses/403Unauthorized'
       404:
         $ref: '#/components/responses/404UserNotFound'
-
-/admin/scan/:
-  post:
-    summary: Scanne le billet d'un utilisateur
-    description: Renvoie les informations de l'utilisateur.<br/>
-      **Permission 'entry' ou 'admin' requise.**<br/>
-      *Le billet ne doit pas avoir été déjà scanné.*
-      *Le billet est passé dans le body et non dans les paramètres car il est chiffré en base64 et peut contenir des slashs*
-    tags:
-      - Admin
-    security:
-      - BearerAuth: []
-    requestBody:
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              qrcode:
-                type: string
-                description: Contenu du QR code présent sur le billet chiffré
-              userId:
-                type: string
-                description: Peut remplacer le QR code si la lecture est trop longue/compliquée.
-                  Cette propriété ne peut pas être envoyée en même temps que `qrcode`
-    responses:
-      200:
-        description: Renvoie les informations de l'utilisateur et son équipe
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UserWithTeamAndMessageAndTournamentInfo'
-      400:
-        $ref: '#/components/responses/400Errored'
-      401:
-        $ref: '#/components/responses/401Unauthenticated'
-      403:
-        $ref: '#/components/responses/403Unauthorized'
-      404:
-        description: Aucun utilisateur n'est associé à ce QR code
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Error'
-            example:
-              error: Aucun utilisateur n'est associé à ce QR code

--- a/src/controllers/openapi.yml
+++ b/src/controllers/openapi.yml
@@ -186,9 +186,16 @@ components:
               description: Le titre écrit en très gros en tout début de mail, en dessous du logo
         content:
           type: array
-          items:
-            $ref: '#/components/schemas/MailSection'
           description: Contenu du mail
+          items:
+            type: object
+            properties:
+              title:
+                type: string
+              components:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MailSection'
         sentAt:
           type: string
           format: date-time

--- a/src/controllers/openapi.yml
+++ b/src/controllers/openapi.yml
@@ -170,6 +170,20 @@ components:
         subject:
           type: string
           description: Sujet du mail
+        reason:
+          type: string
+          description: La raison de l'envoi du mail. Cette information apparaîtra dans le pied de page du mail
+          optional: true
+        highlight:
+          type: object
+          description: L'entête au début de chaque mail (en dessous de la partie noire avec le logo)
+          properties:
+            intro:
+              type: string
+              description: Le message écrit avec une petite police, juste avant le `hightlight.title`
+            title:
+              type: string
+              description: Le titre écrit en très gros en tout début de mail, en dessous du logo
         content:
           type: array
           items:
@@ -192,7 +206,6 @@ components:
             Autrement, si elle vaut `false`, seuls les joueurs **membres d'équipes non validées** recevront le mail.
             Sinon, si elle vaut `true`, seuls les joueurs **membres d'équipes validées** recevront le mail.
           optional: true
-          nullable: true
         tournamentId:
           type: string
           example: lolCompetitive
@@ -201,22 +214,44 @@ components:
             *Cette propriété **peut** être utilisée avec `locked` pour envoyer un mail aux équipes non validées d'un certain
             tournoi (par exemple s'il y a moins de places disponibles que d'équipes crées).*
           optional: true
-          nullable: true
         preview:
           type: boolean
           description: Permet de n'envoyer le mail qu'à l'utilisateur actuel, afin de vérifier la mise en page
             et le contenu.
           default: false
           optional: true
-          nullable: true
         subject:
           type: string
           description: Sujet du mail
           required: true
+        reason:
+          type: string
+          description: La raison de l'envoi du mail. Cette information apparaîtra dans le pied de page du mail
+          optional: true
+        highlight:
+          type: object
+          description: L'entête au début de chaque mail (en dessous de la partie noire avec le logo)
+          required: true
+          properties:
+            intro:
+              type: string
+              description: Le message écrit avec une petite police, juste avant le `hightlight.title`
+              required: true
+            title:
+              type: string
+              description: Le titre écrit en très gros en tout début de mail, en dessous du logo
+              required: true
         content:
           type: array
           items:
-            $ref: '#/components/schemas/MailSection'
+            type: object
+            properties:
+              title:
+                type: string
+              components:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MailSection'
           description: Contenu du mail
           required: true
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,11 @@ export type MailQuery = ParsedQs & {
   readonly tournamentId?: TournamentId;
   readonly preview: boolean;
   readonly subject: string;
+  readonly highlight: {
+    readonly title: string;
+    readonly intro: string;
+  };
+  readonly reason?: string;
   readonly content: Email['sections'];
 };
 
@@ -241,7 +246,9 @@ export const enum Error {
 
   InvalidCart = 'Le contenu de la commande est invalide',
   EmptyLogin = "Le nom d'utilisateur ne peut pas être vide",
+
   MalformedMailBody = 'Structure du mail incorrecte',
+  InvalidMailOptions = "Paramètres d'envoi incorrects",
 
   // 401
   // The user credentials were refused or not provided

--- a/tests/admin/emails/get.test.ts
+++ b/tests/admin/emails/get.test.ts
@@ -42,6 +42,10 @@ describe('GET /admin/emails', () => {
   it('should fetch one mail', async () => {
     const mailContent = {
       subject: 'Very important news&nbsp;!',
+      highlight: {
+        intro: 'Hi, are you ready to',
+        title: 'Save the date ?',
+      },
       content: [
         {
           title: 'Save the date&nbsp;!',
@@ -92,6 +96,10 @@ describe('GET /admin/emails', () => {
     await database.log.deleteMany();
     const mailContent = {
       subject: 'Very important news&nbsp;!',
+      highlight: {
+        intro: 'Hi, are you ready to',
+        title: 'Save the date ?',
+      },
       content: [
         {
           title: 'Save the date&nbsp;!',

--- a/tests/admin/emails/send.test.ts
+++ b/tests/admin/emails/send.test.ts
@@ -56,6 +56,10 @@ describe('POST /admin/emails', () => {
         .post(`/admin/emails`)
         .send({
           subject: 'Test',
+          highlight: {
+            intro: 'Is this a',
+            title: 'Test ?',
+          },
           content: [
             {
               title: 'Section',
@@ -75,6 +79,10 @@ describe('POST /admin/emails', () => {
         .post(`/admin/emails`)
         .send({
           subject: 'Test',
+          highlight: {
+            intro: 'Is this a',
+            title: 'Test ?',
+          },
           content: [
             {
               title: 'Section',
@@ -92,6 +100,10 @@ describe('POST /admin/emails', () => {
         .post(`/admin/emails`)
         .send({
           subject: 'Test',
+          highlight: {
+            intro: 'Is this a',
+            title: 'Test ?',
+          },
           content: [
             {
               title: 'Section',
@@ -107,12 +119,17 @@ describe('POST /admin/emails', () => {
   describe('Test mail recipient filters', () => {
     const validMailBody = {
       subject: "Tomorrow's tournament cancelled due to extreme weather conditions",
+      highlight: {
+        intro: 'Is this a',
+        title: 'Test ?',
+      },
       content: [
         {
           title: 'Why did we choose to cancel the tournament ?',
           components: ["There was definitely no reason for that. We're just too lazy. _That's it_"],
         },
       ],
+      reason: 'You should not have received this email as it has been generated for test purposes...',
     };
 
     it('should successfully send a valid preview mail to the sender (only)', () =>


### PR DESCRIPTION
C'est très le fix

Plus en détails:
- `POST /admin/emails` peut définir une raison à l'envoi du mail *(ça part dans le pied de page du mail)* et **doit** choisir le contenu du *highlight* (ouais parce qu'avant c'était le titre qui était répété 3 fois)
- `POST /admin/emails` n'enverra plus de mails aux utilisateurs qui n'ont pas vérifié leur adresse email (ni aux utilisateurs qui n'ont pas d'adresse email, comme les `UserType#attendant` par exemple...)
- Corrections de la doc de l'api (l'ordre alphabétique des routes dans le `/admin`, il manquait les sections dans la syntaxe de la route `POST /admin/emails`, des `nullable` qui n'avaient rien à faire là)