### PR TITLE
fix: add support for rent items and attendant drop with stale carts

### DIFF
--- a/schema.prisma
+++ b/schema.prisma
@@ -54,7 +54,7 @@ model Item {
   attribute    String?
   price        Int
   reducedPrice Int?
-  infos        String?
+  infos        String?      @db.VarChar(300)
   image        String?
   stock        Int?
   cartItems    CartItem[]
@@ -164,6 +164,7 @@ enum TransactionState {
 enum ItemCategory {
   ticket
   supplement
+  rent
 }
 
 enum UserType {

--- a/seed.sql
+++ b/seed.sql
@@ -11,7 +11,8 @@ INSERT INTO `items` (`id`, `name`, `category`, `attribute`, `price`, `reducedPri
 ('tshirt-s', 'T-shirt UA 2022 (Unixese)', 'supplement', 's', 1500, NULL, 'Un t-shirt souvenir de cette LAN de folie', 'tshirt.png', 30),
 ('tshirt-m', 'T-shirt UA 2022 (Unixese)', 'supplement', 'm', 1500, NULL, 'Un t-shirt souvenir de cette LAN de folie', 'tshirt.png', 30),
 ('tshirt-l', 'T-shirt UA 2022 (Unixese)', 'supplement', 'l', 1500, NULL, 'Un t-shirt souvenir de cette LAN de folie', 'tshirt.png', 30),
-('tshirt-xl', 'T-shirt UA 2022 (Unixese)', 'supplement', 'xl', 1500, NULL, 'Un t-shirt souvenir de cette LAN de folie', 'tshirt.png', 30);
+('tshirt-xl', 'T-shirt UA 2022 (Unixese)', 'supplement', 'xl', 1500, NULL, 'Un t-shirt souvenir de cette LAN de folie', 'tshirt.png', 30)
+('pc', 'Location de PC', 'rent', NULL, 14000, NULL, 'Location de PC si tu ne peux pas amener le tien pendant l\'UTT Arena. L\'un des PC suivants sera mis à ta disposition :->AMD Ryzen 5 2600,16GB RAM SSD 500G° et 2060 ou 6600XT->INTEL I5 8500 16GB RAM SSD 500G° et 2060 ou 6600XT->AMD RYZEN 5 5600X 500G° SSD et 2060 ou 6600XT', NULL, 7);
 
 INSERT INTO `settings` (`id`, `value`) VALUES
 ('login', 0),

--- a/seed.sql
+++ b/seed.sql
@@ -12,7 +12,7 @@ INSERT INTO `items` (`id`, `name`, `category`, `attribute`, `price`, `reducedPri
 ('tshirt-m', 'T-shirt UA 2022 (Unixese)', 'supplement', 'm', 1500, NULL, 'Un t-shirt souvenir de cette LAN de folie', 'tshirt.png', 30),
 ('tshirt-l', 'T-shirt UA 2022 (Unixese)', 'supplement', 'l', 1500, NULL, 'Un t-shirt souvenir de cette LAN de folie', 'tshirt.png', 30),
 ('tshirt-xl', 'T-shirt UA 2022 (Unixese)', 'supplement', 'xl', 1500, NULL, 'Un t-shirt souvenir de cette LAN de folie', 'tshirt.png', 30)
-('pc', 'Location de PC', 'rent', NULL, 14000, NULL, 'Location de PC si tu ne peux pas amener le tien pendant l\'UTT Arena. L\'un des PC suivants sera mis à ta disposition :->AMD Ryzen 5 2600,16GB RAM SSD 500G° et 2060 ou 6600XT->INTEL I5 8500 16GB RAM SSD 500G° et 2060 ou 6600XT->AMD RYZEN 5 5600X 500G° SSD et 2060 ou 6600XT', NULL, 7);
+('pc', 'Location de PC', 'rent', NULL, 14000, NULL, 'Location de PC si tu ne peux pas amener le tien pendant l''UTT Arena. L''un des PC suivants sera mis à ta disposition :->AMD Ryzen 5 2600,16GB RAM SSD 500G° et 2060 ou 6600XT->INTEL I5 8500 16GB RAM SSD 500G° et 2060 ou 6600XT->AMD RYZEN 5 5600X 500G° SSD et 2060 ou 6600XT', NULL, 7);
 
 INSERT INTO `settings` (`id`, `value`) VALUES
 ('login', 0),

--- a/seed.sql
+++ b/seed.sql
@@ -11,7 +11,7 @@ INSERT INTO `items` (`id`, `name`, `category`, `attribute`, `price`, `reducedPri
 ('tshirt-s', 'T-shirt UA 2022 (Unixese)', 'supplement', 's', 1500, NULL, 'Un t-shirt souvenir de cette LAN de folie', 'tshirt.png', 30),
 ('tshirt-m', 'T-shirt UA 2022 (Unixese)', 'supplement', 'm', 1500, NULL, 'Un t-shirt souvenir de cette LAN de folie', 'tshirt.png', 30),
 ('tshirt-l', 'T-shirt UA 2022 (Unixese)', 'supplement', 'l', 1500, NULL, 'Un t-shirt souvenir de cette LAN de folie', 'tshirt.png', 30),
-('tshirt-xl', 'T-shirt UA 2022 (Unixese)', 'supplement', 'xl', 1500, NULL, 'Un t-shirt souvenir de cette LAN de folie', 'tshirt.png', 30)
+('tshirt-xl', 'T-shirt UA 2022 (Unixese)', 'supplement', 'xl', 1500, NULL, 'Un t-shirt souvenir de cette LAN de folie', 'tshirt.png', 30),
 ('pc', 'Location de PC', 'rent', NULL, 14000, NULL, 'Location de PC si tu ne peux pas amener le tien pendant l''UTT Arena. L''un des PC suivants sera mis à ta disposition :->AMD Ryzen 5 2600,16GB RAM SSD 500G° et 2060 ou 6600XT->INTEL I5 8500 16GB RAM SSD 500G° et 2060 ou 6600XT->AMD RYZEN 5 5600X 500G° SSD et 2060 ou 6600XT', NULL, 7);
 
 INSERT INTO `settings` (`id`, `value`) VALUES

--- a/src/controllers/users/createCart.ts
+++ b/src/controllers/users/createCart.ts
@@ -123,7 +123,9 @@ export default [
       // Manage the supplement part. For now, the user can only buy supplements for himself
       for (const supplement of body.supplements) {
         const currentItem = items.find(
-          (item) => item.id === supplement.itemId && item.category === ItemCategory.supplement,
+          (item) =>
+            item.id === supplement.itemId &&
+            (item.category === ItemCategory.supplement || item.category === ItemCategory.rent),
         );
         // User cannot buy this item, either because he is not allowed to, or because the item doesn't exist
         if (!currentItem) {
@@ -166,7 +168,7 @@ export default [
       const itemsWithStock = items.filter((item) => item.left !== undefined);
 
       // Wait for sql delete query to end (if not already ended)
-      const { count: droppedCartsCount } = await dropOperation;
+      const [, { count: droppedCartsCount }] = await dropOperation;
       // Check if rows (ie. carts) were updated
       if (droppedCartsCount > 0) {
         // Update fetched items

--- a/src/operations/item.ts
+++ b/src/operations/item.ts
@@ -1,5 +1,5 @@
 import database from '../services/database';
-import { Item, Team, TransactionState, User } from '../types';
+import { Item, ItemCategory, Team, TransactionState, User, UserType } from '../types';
 import { isPartnerSchool } from '../utils/helpers';
 
 export const fetchAllItems = async (): Promise<Item[]> => {
@@ -65,6 +65,11 @@ export const fetchUserItems = async (team?: Team, user?: User) => {
     // The user then has a pending cart with a SSBU discount
     // Before being able to add it to his cart again, he needs to wait an hour for the cart to expire (and not pay it during that time)
     items.find((element) => element.id === 'discount-switch-ssbu').left = -1;
+  }
+
+  if (!user || user.type !== UserType.player || !team || team.tournamentId === 'ssbu') {
+    // Remove rents
+    items = items.filter((element) => element.category !== ItemCategory.rent);
   }
 
   const currentTicket =

--- a/src/services/email/serializer.ts
+++ b/src/services/email/serializer.ts
@@ -83,7 +83,7 @@ export const generateTicketsEmail = (cart: DetailedCart) =>
                 .map((ticket) => ({
                   name: `${ticket.forUser.firstname} ${ticket.forUser.lastname}`,
                   type: ticket.item.name,
-                  price: formatPrice(ticket.item.price),
+                  price: formatPrice(ticket.price),
                 })),
             ],
           },
@@ -100,7 +100,24 @@ export const generateTicketsEmail = (cart: DetailedCart) =>
                 .map((item) => ({
                   name: item.item.name,
                   amount: `${item.quantity}`,
-                  price: formatPrice(item.item.price),
+                  price: formatPrice(item.price),
+                })),
+            ],
+          },
+          {
+            name: 'Location de matériel',
+            items: [
+              {
+                name: '*Nom*',
+                amount: '*Quantité*',
+                price: '*Prix*',
+              },
+              ...cart.cartItems
+                .filter((cartItem) => cartItem.item.category === ItemCategory.rent)
+                .map((item) => ({
+                  name: item.item.name,
+                  amount: `${item.quantity}`,
+                  price: formatPrice(item.price),
                 })),
             ],
           },

--- a/tests/items/getItems.test.ts
+++ b/tests/items/getItems.test.ts
@@ -58,16 +58,16 @@ describe('GET /items', () => {
     const items = await database.item.findMany();
     const response = await request(app).get('/items').expect(200);
 
-    // without the "discount-switch-ssbu" item and the "ticket-player-ssbu"
-    expect(response.body).to.have.lengthOf(items.length - 2);
+    // without the "discount-switch-ssbu" item and the "ticket-player-ssbu" and the "pc" (in rent category)
+    expect(response.body).to.have.lengthOf(items.length - 3);
   });
 
   it('should return 200 with an array of items with the "discount-switch-ssbu" item', async () => {
     const items = await database.item.findMany();
     const response = await request(app).get('/items').set('Authorization', `Bearer ${captainToken}`).expect(200);
 
-    // with the "discount-switch-ssbu" item but without the legacy "ticket-player"
-    expect(response.body).to.have.lengthOf(items.length - 1);
+    // with the "discount-switch-ssbu" item but without the legacy "ticket-player" and without "pc" (in rent category)
+    expect(response.body).to.have.lengthOf(items.length - 2);
   });
 
   it(`should return 200 with an array of items with the "discount-switch-ssbu" and a quantity of -1 item because user has a pending cart containing it`, async () => {
@@ -75,8 +75,8 @@ describe('GET /items', () => {
     const items = await database.item.findMany();
     const response = await request(app).get('/items').set('Authorization', `Bearer ${thirdCaptainToken}`).expect(200);
 
-    // without the legacy "ticket-player"
-    expect(response.body).to.have.lengthOf(items.length - 1);
+    // without the legacy "ticket-player" and without "pc" (in rent category)
+    expect(response.body).to.have.lengthOf(items.length - 2);
     expect(response.body.find((item: Item) => item.id === 'discount-switch-ssbu').left).to.be.equal(-1);
   });
 
@@ -85,8 +85,8 @@ describe('GET /items', () => {
     const items = await database.item.findMany();
     const response = await request(app).get('/items').set('Authorization', `Bearer ${thirdCaptainToken}`).expect(200);
 
-    // without the "discount-switch-ssbu" item and the legacy "ticket-player"
-    expect(response.body).to.have.lengthOf(items.length - 2);
+    // without the "discount-switch-ssbu" item and the legacy "ticket-player" and without "pc" (in rent category)
+    expect(response.body).to.have.lengthOf(items.length - 3);
   });
 
   describe('should return 200 with an array of items with the "discount-switch-ssbu" item because user has a cart containing it, but it was not paid nor it is pending', () => {
@@ -100,8 +100,8 @@ describe('GET /items', () => {
           .set('Authorization', `Bearer ${thirdCaptainToken}`)
           .expect(200);
 
-        // with the "discount-switch-ssbu" item but without the legaycy "ticket-player"
-        expect(response.body).to.have.lengthOf(items.length - 1);
+        // with the "discount-switch-ssbu" item but without the legaycy "ticket-player" and without "pc" (in rent category)
+        expect(response.body).to.have.lengthOf(items.length - 2);
       });
     }
   });
@@ -110,7 +110,7 @@ describe('GET /items', () => {
     const items = await database.item.findMany();
     const response = await request(app).get('/items').set('Authorization', `Bearer ${otherCaptainToken}`).expect(200);
 
-    // without the "discount-switch-ssbu" item and the "ticket-player-ssbu"
+    // without the "discount-switch-ssbu" item and the "ticket-player-ssbu" but with "pc" (in rent category)
     expect(response.body).to.have.lengthOf(items.length - 2);
   });
 

--- a/tests/items/getItems.test.ts
+++ b/tests/items/getItems.test.ts
@@ -100,7 +100,7 @@ describe('GET /items', () => {
           .set('Authorization', `Bearer ${thirdCaptainToken}`)
           .expect(200);
 
-        // with the "discount-switch-ssbu" item but without the legaycy "ticket-player" and without "pc" (in rent category)
+        // with the "discount-switch-ssbu" item but without the legacy "ticket-player" and without "pc" (in rent category)
         expect(response.body).to.have.lengthOf(items.length - 2);
       });
     }

--- a/tests/users/createCart.test.ts
+++ b/tests/users/createCart.test.ts
@@ -427,11 +427,11 @@ describe('POST /users/current/carts', () => {
 
   it('should error as spectator cannot rent a pc', async () => {
     const spectator = await createFakeUser({ type: UserType.spectator });
-    const token = generateToken(spectator);
+    const specToken = generateToken(spectator);
 
     return request(app)
       .post(`/users/current/carts`)
-      .set('Authorization', `Bearer ${token}`)
+      .set('Authorization', `Bearer ${specToken}`)
       .send({
         tickets: {
           userIds: [],
@@ -447,11 +447,11 @@ describe('POST /users/current/carts', () => {
   });
 
   it('should sucessfully create a cart with a rental pc', async () => {
-    const token = generateToken(notValidUserWithSwitchDiscount);
+    const userToken = generateToken(notValidUserWithSwitchDiscount);
 
     const { body } = await request(app)
       .post(`/users/current/carts`)
-      .set('Authorization', `Bearer ${token}`)
+      .set('Authorization', `Bearer ${userToken}`)
       .send({
         tickets: {
           userIds: [],

--- a/tests/users/createCart.test.ts
+++ b/tests/users/createCart.test.ts
@@ -425,6 +425,49 @@ describe('POST /users/current/carts', () => {
     expect(supplement?.quantity).to.be.equal(validCartWithSwitchDiscount.supplements[0].quantity);
   });
 
+  it('should error as spectator cannot rent a pc', async () => {
+    const spectator = await createFakeUser({ type: UserType.spectator });
+    const token = generateToken(spectator);
+
+    return request(app)
+      .post(`/users/current/carts`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        tickets: {
+          userIds: [],
+        },
+        supplements: [
+          {
+            itemId: 'pc',
+            quantity: 1,
+          },
+        ],
+      })
+      .expect(404, { error: Error.ItemNotFound });
+  });
+
+  it('should sucessfully create a cart with a rental pc', async () => {
+    const token = generateToken(notValidUserWithSwitchDiscount);
+
+    const { body } = await request(app)
+      .post(`/users/current/carts`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        tickets: {
+          userIds: [],
+        },
+        supplements: [
+          {
+            itemId: 'pc',
+            quantity: 1,
+          },
+        ],
+      })
+      .expect(201);
+    expect(body.url).to.startWith(env.etupay.url);
+    expect(body.price).to.be.equal(14000);
+  });
+
   it('should send an error as ssbu discount is already in a pending cart', async () => {
     await request(app)
       .post(`/users/current/carts`)


### PR DESCRIPTION
Ajoute la location de matériel avec un type différent de `supplement` afin de mieux les afficher sur le front.
Ajout de la suppression automatique des accompagnateurs lorsqu'un panier est supprimé pour inactivité