### PR TITLE
feat: add etupay callback checks

### DIFF
--- a/schema.prisma
+++ b/schema.prisma
@@ -159,6 +159,7 @@ enum TransactionState {
   canceled
   refused
   refunded
+  authorization
 }
 
 enum ItemCategory {

--- a/src/controllers/etupay/callback.ts
+++ b/src/controllers/etupay/callback.ts
@@ -105,7 +105,8 @@ export const bankCallback = [
       // If the transaction is already errored
       if (
         cart.transactionState !== TransactionState.authorization &&
-        cart.transactionState !== TransactionState.pending
+        cart.transactionState !== TransactionState.pending &&
+        etupayResponse.step === TransactionState.paid
       ) {
         return forbidden(response, Error.AlreadyErrored);
       }
@@ -113,8 +114,9 @@ export const bankCallback = [
       // Update the cart with the callback data
       const updatedCart = await updateCart(cartId, etupayResponse.transactionId, etupayResponse.step);
 
-      // Send the tickets to the user
-      await sendPaymentConfirmation(updatedCart);
+      if (updatedCart.transactionState === TransactionState.paid)
+        // Send the tickets to the user
+        await sendPaymentConfirmation(updatedCart);
 
       return success(response, { api: 'ok' });
     } catch (error) {

--- a/src/controllers/etupay/callback.ts
+++ b/src/controllers/etupay/callback.ts
@@ -5,6 +5,7 @@ import * as etupay from '../../services/etupay';
 import { Error, EtupayError, EtupayResponse, TransactionState } from '../../types';
 import env from '../../utils/env';
 import { decodeFromBase64 } from '../../utils/helpers';
+import { getIp } from '../../utils/network';
 import { badRequest, forbidden, notFound, success } from '../../utils/responses';
 
 // Called by the client
@@ -36,7 +37,7 @@ export const clientCallback = [
       }
 
       // If the transaction is already paid
-      if (cart.transactionState === TransactionState.paid) {
+      if (cart.transactionState === TransactionState.paid || cart.transactionState === TransactionState.authorization) {
         return forbidden(response, Error.AlreadyPaid);
       }
 
@@ -46,15 +47,16 @@ export const clientCallback = [
       }
 
       // Update the cart with the callback data
-      const updatedCart = await updateCart(cartId, etupayResponse.transactionId, etupayResponse.step);
+      await updateCart(
+        cartId,
+        etupayResponse.transactionId,
+        etupayResponse.step === TransactionState.paid ? TransactionState.authorization : etupayResponse.step,
+      );
 
       // If the transaction state wasn't paid, redirect to the error url
       if (!etupayResponse.paid) {
         return response.redirect(env.etupay.errorUrl);
       }
-
-      // Send the tickets to the user
-      await sendPaymentConfirmation(updatedCart);
 
       return response.redirect(env.etupay.successUrl);
     } catch (error) {
@@ -64,4 +66,59 @@ export const clientCallback = [
 ];
 
 // Called by the bank few minutes after
-export const bankCallback = (request: Request, response: Response) => success(response, { api: 'ok' });
+export const bankCallback = [
+  // Use the middleware to decrypt the data
+  etupay.middleware,
+
+  // Create a small middleware to be able to handle payload errors.
+  // The eslint disabling is important because the error argument can only be gotten in the 4 arguments function
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  (error: EtupayError, request: Request, response: Response, next: NextFunction) =>
+    badRequest(response, Error.InvalidQueryParameters),
+
+  async (request: Request, response: Response, next: NextFunction) => {
+    if (!/^10\./.test(getIp(request))) {
+      // Not sent by a local ip (eg. etupay)
+      return forbidden(response, Error.EtupayNoAccess);
+    }
+    try {
+      // Retreive the base64 payload
+      const etupayResponse = response.locals.etupay as EtupayResponse;
+
+      // Decode the base64 string to an object
+      const decoded = decodeFromBase64(etupayResponse.serviceData);
+      const { cartId } = decoded;
+
+      // Fetch the cart from the cartId
+      const cart = await fetchCart(cartId);
+
+      // If the cart wasn't found, return a 404
+      if (!cart) {
+        return notFound(response, Error.CartNotFound);
+      }
+
+      // If the transaction is already paid
+      if (cart.transactionState === TransactionState.paid) {
+        return forbidden(response, Error.AlreadyPaid);
+      }
+
+      // If the transaction is already errored
+      if (
+        cart.transactionState !== TransactionState.authorization &&
+        cart.transactionState !== TransactionState.pending
+      ) {
+        return forbidden(response, Error.AlreadyErrored);
+      }
+
+      // Update the cart with the callback data
+      const updatedCart = await updateCart(cartId, etupayResponse.transactionId, etupayResponse.step);
+
+      // Send the tickets to the user
+      await sendPaymentConfirmation(updatedCart);
+
+      return success(response, { api: 'ok' });
+    } catch (error) {
+      return next(error);
+    }
+  },
+];

--- a/src/types.ts
+++ b/src/types.ts
@@ -305,6 +305,7 @@ export const enum Error {
   AlreadyHasPendingCartWithDiscountSSBU = "Tu as déjà un panier en attente de paiement avec une réduction SSBU. Ce panier expirera au bout d'une heure, tu pourras alors rajouter l'item à ton panier",
   NotWhitelisted = "Tu n'es pas qualifié pour ce tournoi",
   HasAlreadyPaidForAnotherTicket = 'Tu as déjà payé un ticket vendu à un prix différent. Pour changer de tournoi, contacte nous !',
+  EtupayNoAccess = "Tu n'as pas accès à cette url",
 
   // 404
   // The server can't find the requested resource


### PR DESCRIPTION
Croire le client c'est bien mais avoir une confirmation d'etupay c'est mieux

Du coup si un paiement est effectué et qu'etupay envoie un mail (ie. exécute le paiement), on récupère l'info aussi ! Ce, même si le *gentil* utilisateur n'a pas été capable de ne pas fermer son onglet !