### PR TITLE
feat: only 1 coach is allowed per 1-player-tournament team

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -6,4 +6,4 @@ spec: 'tests/**/*.test.ts'
 
 watch-extensions: ts
 
-timeout: 10000
+timeout: 30000

--- a/src/controllers/admin/tournaments/updateTournament.ts
+++ b/src/controllers/admin/tournaments/updateTournament.ts
@@ -2,7 +2,7 @@ import Joi from 'joi';
 import { Request, Response, NextFunction } from 'express';
 import { hasPermission } from '../../../middlewares/authentication';
 import { validateBody } from '../../../middlewares/validation';
-import { notFound, success } from '../../../utils/responses';
+import { conflict, notFound, success } from '../../../utils/responses';
 import { Error, Permission } from '../../../types';
 import { fetchTournaments, updateTournament } from '../../../operations/tournament';
 import { addCasterToTournament, removeAllCastersFromTournament } from '../../../operations/caster';
@@ -30,8 +30,18 @@ export default [
   // Controller
   async (request: Request, response: Response, next: NextFunction) => {
     try {
-      if (!(await fetchTournaments()).some((tournament) => tournament.id === request.params.tournamentId)) {
+      const allTournaments = await fetchTournaments();
+      if (!allTournaments.some((tournament) => tournament.id === request.params.tournamentId)) {
         return notFound(response, Error.NotFound);
+      }
+
+      if (
+        request.body.name &&
+        allTournaments.some(
+          (tournament) => tournament.name === request.body.name && tournament.id !== request.params.tournamentId,
+        )
+      ) {
+        return conflict(response, Error.TournamentNameAlreadyExists);
       }
 
       if (request.body.casters && request.body.casters.length > 0) {
@@ -40,6 +50,7 @@ export default [
         for (const casterName of request.body.casters) {
           await addCasterToTournament(request.params.tournamentId as string, casterName);
         }
+        request.body.casters = undefined;
       }
 
       const result = await updateTournament(request.params.tournamentId as string, request.body);

--- a/src/controllers/teams/acceptRequest.ts
+++ b/src/controllers/teams/acceptRequest.ts
@@ -34,6 +34,10 @@ export default [
         return forbidden(response, Error.TeamFull);
       }
 
+      if (team.coaches.length >= Math.min(tournament.playersPerTeam, 2) && askingUser.type === UserType.coach) {
+        return forbidden(response, Error.TeamMaxCoachReached);
+      }
+
       await joinTeam(team.id, askingUser, askingUser.type);
 
       const updatedTeam = await fetchTeam(team.id);

--- a/src/controllers/teams/createTeamRequest.ts
+++ b/src/controllers/teams/createTeamRequest.ts
@@ -47,9 +47,6 @@ export default [
 
       return success(response, filterUser(updatedUser));
     } catch (error) {
-      // This may happen when max coach amount is reached already
-      if (error.code === 'API_COACH_MAX_TEAM') return forbidden(response, ResponseError.TeamMaxCoachReached);
-
       return next(error);
     }
   },

--- a/src/operations/team.ts
+++ b/src/operations/team.ts
@@ -11,11 +11,9 @@ import {
   PrimitiveTeamWithPartialTournament,
 } from '../types';
 import nanoid from '../utils/nanoid';
-import { countCoaches, formatUser, userInclusions } from './user';
+import { formatUser, userInclusions } from './user';
 import { setupDiscordTeam } from '../utils/discord';
 import { fetchTournament } from './tournament';
-
-const teamMaxCoachCount = 2;
 
 const teamInclusions = {
   users: {
@@ -205,13 +203,6 @@ export const updateTeam = async (teamId: string, name: string): Promise<Team> =>
 };
 
 export const askJoinTeam = async (teamId: string, userId: string, userType: UserType) => {
-  // We check the amount of coaches at that point
-  const teamCoachCount = await countCoaches(teamId);
-  if (userType === UserType.coach && teamCoachCount >= teamMaxCoachCount)
-    throw Object.assign(new Error('Query cannot be executed: max count of coach reached already'), {
-      code: 'API_COACH_MAX_TEAM',
-    });
-
   // Then we create the join request when it is alright
   const updatedUser = await database.user.update({
     data: {

--- a/src/operations/tournament.ts
+++ b/src/operations/tournament.ts
@@ -71,7 +71,7 @@ export const updateTournament = (
 ): PrismaPromise<PrimitiveTournament> =>
   database.tournament.update({
     where: { id },
-    data: { ...data, casters: undefined },
+    data: { ...data },
   });
 
 export const updateTournamentsPosition = (tournaments: { id: string; position: number }[]) =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -343,6 +343,7 @@ export const enum Error {
   TeamAlreadyExists = "Le nom de l'équipe existe déjà",
   PlaceAlreadyAttributed = 'Cette place est déjà attribuée',
   DiscordAccountAlreadyUsed = 'Ce compte discord est déjà lié à un compte',
+  TournamentNameAlreadyExists = 'Un tournoi a déjà ce nom',
 
   // 410
   // indicates that access to the target resource is no longer available at the server.

--- a/tests/admin/carts/refund.test.ts
+++ b/tests/admin/carts/refund.test.ts
@@ -11,11 +11,7 @@ import * as userOperations from '../../../src/operations/user';
 import { sandbox } from '../../setup';
 import { generateToken } from '../../../src/utils/users';
 
-// eslint-disable-next-line func-names
-describe('POST /admin/carts/:cartId/refund', function () {
-  // Setup is slow
-  this.timeout(30000);
-
+describe('POST /admin/carts/:cartId/refund', () => {
   let user: User;
   let admin: User;
   let adminToken: string;

--- a/tests/admin/tournaments/updateTournament.test.ts
+++ b/tests/admin/tournaments/updateTournament.test.ts
@@ -15,7 +15,7 @@ describe('PATCH /admin/tournaments/{tournamentId}', () => {
   let tournament: Tournament;
 
   const validBody = {
-    name: 'test',
+    name: 'anothertestname',
     maxPlayers: 100,
     playersPerTeam: 5,
     cashprize: 100,
@@ -31,7 +31,7 @@ describe('PATCH /admin/tournaments/{tournamentId}', () => {
 
   after(async () => {
     await database.user.deleteMany();
-    await database.tournament.delete({ where: { id: tournament.id } });
+    await database.tournament.delete({where: {id: tournament.id}});
   });
 
   before(async () => {
@@ -39,7 +39,7 @@ describe('PATCH /admin/tournaments/{tournamentId}', () => {
     nonAdminUser = await createFakeUser();
     adminToken = generateToken(admin);
 
-    tournament = await createFakeTournament({ id: 'test', name: 'Dragibus', maxTeams: 1, playersPerTeam: 1 });
+    tournament = await createFakeTournament({ id: 'test', name: 'test', playersPerTeam: 1, maxTeams: 1 });
   });
 
   it('should error as the user is not authenticated', () =>
@@ -73,6 +73,14 @@ describe('PATCH /admin/tournaments/{tournamentId}', () => {
       .send(validBody)
       .set('Authorization', `Bearer ${adminToken}`)
       .expect(404, { error: Error.NotFound });
+  });
+
+  it('should fail as a tournament already has this name', async () => {
+    await request(app)
+      .patch(`/admin/tournaments/${tournament.id}`)
+      .send({ name: 'Pokémon' })
+      .set('Authorization', `Bearer ${adminToken}`)
+      .expect(409, { error: Error.TournamentNameAlreadyExists });
   });
 
   it('should successfully update the tournament', async () => {

--- a/tests/admin/tournaments/updateTournament.test.ts
+++ b/tests/admin/tournaments/updateTournament.test.ts
@@ -31,7 +31,7 @@ describe('PATCH /admin/tournaments/{tournamentId}', () => {
 
   after(async () => {
     await database.user.deleteMany();
-    await database.tournament.delete({where: {id: tournament.id}});
+    await database.tournament.delete({ where: { id: tournament.id } });
   });
 
   before(async () => {

--- a/tests/admin/users/forcePay.test.ts
+++ b/tests/admin/users/forcePay.test.ts
@@ -12,11 +12,7 @@ import * as teamOperations from '../../../src/operations/team';
 import * as userOperations from '../../../src/operations/user';
 import * as tournamentOperations from '../../../src/operations/tournament';
 
-// eslint-disable-next-line func-names
-describe('POST /admin/users/:userId/force-pay', function () {
-  // The setup is slow
-  this.timeout(30000);
-
+describe('POST /admin/users/:userId/force-pay', () => {
   let user: User;
   let admin: User;
   let adminToken: string;

--- a/tests/etupay/callback.test.ts
+++ b/tests/etupay/callback.test.ts
@@ -77,11 +77,7 @@ const createCartAndPayload = async (
   };
 };
 
-// eslint-disable-next-line func-names
-describe('POST /etupay/callback', function () {
-  // The setup is slow
-  this.timeout(30000);
-
+describe('POST /etupay/callback', () => {
   let cart: Cart;
   let paidPayload: string;
   let refusedPayload: string;

--- a/tests/teams/acceptRequest.test.ts
+++ b/tests/teams/acceptRequest.test.ts
@@ -37,13 +37,13 @@ describe('POST /teams/current/join-requests/:userId', function () {
     user2 = await createFakeUser({ paid: true, type: UserType.player });
     await teamOperations.askJoinTeam(team.id, user.id, UserType.player);
     await teamOperations.askJoinTeam(team.id, user2.id, UserType.player);
-    fullTeam = await createFakeTeam({ members: tournament.playersPerTeam, paid: true, locked: true });
+    fullTeam = await createFakeTeam({ members: tournament.playersPerTeam, paid: true });
     fullCaptain = getCaptain(fullTeam);
     fullToken = generateToken(fullCaptain);
     // Fill the tournament
     // Store the promises
     const promises = [];
-    for (let index = 1; index < tournament.placesLeft; index++) {
+    for (let index = 0; index < tournament.placesLeft; index++) {
       promises.push(createFakeTeam({ members: tournament.playersPerTeam, paid: true, locked: true }));
     }
     await Promise.all(promises);
@@ -115,11 +115,7 @@ describe('POST /teams/current/join-requests/:userId', function () {
   });
 
   it('should fail as the team is full', async () => {
-    const fullTeam = await createFakeTeam({ members: 5 });
     const otherUser = await createFakeUser();
-
-    const fullCaptain = getCaptain(fullTeam);
-    const fullToken = generateToken(fullCaptain);
     await teamOperations.askJoinTeam(fullTeam.id, otherUser.id, UserType.player);
 
     await request(app)

--- a/tests/teams/acceptRequest.test.ts
+++ b/tests/teams/acceptRequest.test.ts
@@ -13,11 +13,7 @@ import { generateToken } from '../../src/utils/users';
 import { getCaptain } from '../../src/utils/teams';
 import { fetchUser } from '../../src/operations/user';
 
-// eslint-disable-next-line func-names
-describe('POST /teams/current/join-requests/:userId', function () {
-  // Setup is slow
-  this.timeout(30000);
-
+describe('POST /teams/current/join-requests/:userId', () => {
   let user: User;
   let user2: User;
   let team: Team;

--- a/tests/teams/createTeamRequest.test.ts
+++ b/tests/teams/createTeamRequest.test.ts
@@ -54,39 +54,6 @@ describe('POST /teams/:teamId/join-requests', () => {
       .expect(403, { error: Error.AlreadyInTeam });
   });
 
-  it('should fail because coach limit is already reached (coach team members)', async () => {
-    const otherTeam = await createFakeTeam({ members: 2 });
-    const [user1, user2] = otherTeam.players;
-    await updateAdminUser(user1.id, { type: UserType.coach });
-    await updateAdminUser(user2.id, { type: UserType.coach });
-
-    const otherCoach = await createFakeUser();
-    const otherToken = generateToken(otherCoach);
-
-    return request(app)
-      .post(`/teams/${otherTeam.id}/join-requests`)
-      .send({ userType: UserType.coach })
-      .set('Authorization', `Bearer ${otherToken}`)
-      .expect(403, { error: Error.TeamMaxCoachReached });
-  });
-
-  it('should fail because coach limit is already reached (coach team member requests)', async () => {
-    const otherTeam = await createFakeTeam();
-    const [user1] = otherTeam.players;
-    const user2 = await createFakeUser();
-    await updateAdminUser(user1.id, { type: UserType.coach });
-    await teamOperations.askJoinTeam(otherTeam.id, user2.id, UserType.coach);
-
-    const otherCoach = await createFakeUser();
-    const otherToken = generateToken(otherCoach);
-
-    return request(app)
-      .post(`/teams/${otherTeam.id}/join-requests`)
-      .send({ userType: UserType.coach })
-      .set('Authorization', `Bearer ${otherToken}`)
-      .expect(403, { error: Error.TeamMaxCoachReached });
-  });
-
   it('should fail because the user is a spectator', async () => {
     const spectator = await createFakeUser({ type: UserType.spectator });
     const spectatorToken = generateToken(spectator);

--- a/tests/teams/deleteTeam.test.ts
+++ b/tests/teams/deleteTeam.test.ts
@@ -11,11 +11,7 @@ import { createFakeTeam, createFakeUser } from '../utils';
 import { generateToken } from '../../src/utils/users';
 import { getCaptain } from '../../src/utils/teams';
 
-// eslint-disable-next-line func-names
-describe('DELETE /teams/current', function () {
-  // Setup is slow
-  this.timeout(30000);
-
+describe('DELETE /teams/current', () => {
   let captain: User;
   let team: Team;
   let lockedTeam: Team;


### PR DESCRIPTION
* The check for the number of coach is now done on request accept, and not on request creation
* fixed a bug in PATCH /admin/tournaments/:tournamentId

# Breaking change :

coach limit in POST /teams/{teamId]/join-requests
