### PR TITLE
fix: fixed crash when caster array was empty

### DIFF
--- a/src/controllers/admin/tournaments/updateTournament.ts
+++ b/src/controllers/admin/tournaments/updateTournament.ts
@@ -50,8 +50,8 @@ export default [
         for (const casterName of request.body.casters) {
           await addCasterToTournament(request.params.tournamentId as string, casterName);
         }
-        request.body.casters = undefined;
       }
+      request.body.casters = undefined;
 
       const result = await updateTournament(request.params.tournamentId as string, request.body);
 


### PR DESCRIPTION
# Fix crash when no caster was passed to route PATCH /admin/tournaments/:tournamentId

## Changes

Now the request.body.casters is always set to undefined, before it could still be equal to [] after adding casters (if there were none)
