### PR TITLE
fix: any number of teams can now be created per tournament

### DIFF
--- a/src/controllers/teams/createTeam.ts
+++ b/src/controllers/teams/createTeam.ts
@@ -42,11 +42,6 @@ export default [
         return notFound(response, ResponseError.TournamentNotFound);
       }
 
-      // If there are more or equal teams than places, return a tournament full
-      if (tournament.placesLeft === 0) {
-        return gone(response, ResponseError.TournamentFull);
-      }
-
       // Check whether the user has already paid for another ticket
       if (await hasUserAlreadyPaidForAnotherTicket(user, tournamentId, userType))
         return forbidden(response, ResponseError.HasAlreadyPaidForAnotherTicket);

--- a/src/controllers/teams/createTeam.ts
+++ b/src/controllers/teams/createTeam.ts
@@ -9,7 +9,7 @@ import { fetchTournament } from '../../operations/tournament';
 import { hasUserAlreadyPaidForAnotherTicket } from '../../operations/user';
 import { Error as ResponseError, UserType } from '../../types';
 import { filterTeam } from '../../utils/filters';
-import { badRequest, conflict, created, forbidden, gone, notFound } from '../../utils/responses';
+import { badRequest, conflict, created, forbidden, notFound } from '../../utils/responses';
 import { getRequestInfo } from '../../utils/users';
 import * as validators from '../../utils/validators';
 

--- a/src/controllers/teams/openapi.yml
+++ b/src/controllers/teams/openapi.yml
@@ -92,8 +92,6 @@
         $ref: '#/components/responses/401Unauthenticated'
       409:
         description: Le nom de l'équipe existe déjà
-      410:
-        description: Le tournoi est plein
 /teams/{teamId}:
   get:
     summary: Renvoie une équipe

--- a/src/types.ts
+++ b/src/types.ts
@@ -347,7 +347,6 @@ export const enum Error {
 
   // 410
   // indicates that access to the target resource is no longer available at the server.
-  TournamentFull = 'Le tournoi est complet',
   ItemOutOfStock = "L'objet demandé n'est plus en stock",
   ItemNotAvailableAnymore = "L'objet demandé n'est plus disponible",
 

--- a/tests/teams/createTeam.test.ts
+++ b/tests/teams/createTeam.test.ts
@@ -234,28 +234,6 @@ describe('POST /teams', () => {
       .expect(403, { error: Error.HasAlreadyPaidForAnotherTicket });
   });
 
-  it('should error as the tournament is full', async () => {
-    await createFakeTeam({ members: 5, locked: true });
-    const otherUser = await createFakeUser();
-    const otherToken = generateToken(otherUser);
-
-    // We limit the tournament to only one team (as only one has locked)
-    await database.tournament.update({
-      data: {
-        maxPlayers: 5,
-      },
-      where: {
-        id: 'lol',
-      },
-    });
-
-    return request(app)
-      .post('/teams')
-      .send({ name: 'otherName', tournamentId: teamBody.tournamentId, userType: teamBody.userType })
-      .set('Authorization', `Bearer ${otherToken}`)
-      .expect(410, { error: Error.TournamentFull });
-  });
-
   it('should deny orga captain type', async () => {
     const newUser = await createFakeUser();
     const newToken = generateToken(newUser);


### PR DESCRIPTION
# Made it so that any number of teams can be created per tournament (but still a few can be locked)
