### PR TITLE
fix: a lot of small problems of route PATCH /admin/tournaments/:id

### DIFF
--- a/src/controllers/admin/openapi.yml
+++ b/src/controllers/admin/openapi.yml
@@ -194,7 +194,8 @@
 /admin/items/:itemId:
   patch:
     summary: Change les informations de l'item.
-    description: Change les informations de l'item ":" nom, catégorie, attribut, prix, informations, image, stock, dates de disponibilité.
+    description:
+      Change les informations de l'item ":" nom, catégorie, attribut, prix, informations, image, stock, dates de disponibilité.
       **Permission 'admin' requise.**
     tags:
       - Admin
@@ -532,7 +533,6 @@
               error: L'utilisateur n'est pas authentifié
       403:
         $ref: '#/components/responses/403Unauthorized'
-
 
 /admin/repo/user:
   get:
@@ -926,12 +926,6 @@
               maxPlayers:
                 type: integer
                 description: Le nombre maximum de joueurs
-              playersPerTeam:
-                type: integer
-                description: Le nombre de joueurs par équipe
-              coachesPerTeam:
-                type: integer
-                description: Le nombre maximal de coach par équipe
               cashprize:
                 type: integer
                 description: Le cashprize du tournoi

--- a/src/controllers/admin/tournaments/updateTournament.ts
+++ b/src/controllers/admin/tournaments/updateTournament.ts
@@ -2,7 +2,7 @@ import Joi from 'joi';
 import { Request, Response, NextFunction } from 'express';
 import { hasPermission } from '../../../middlewares/authentication';
 import { validateBody } from '../../../middlewares/validation';
-import { conflict, notFound, success } from '../../../utils/responses';
+import { conflict, forbidden, notFound, success } from '../../../utils/responses';
 import { Error, Permission } from '../../../types';
 import { fetchTournaments, updateTournament } from '../../../operations/tournament';
 import { addCasterToTournament, removeAllCastersFromTournament } from '../../../operations/caster';
@@ -14,8 +14,6 @@ export default [
     Joi.object({
       name: Joi.string().optional(),
       maxPlayers: Joi.number().optional(),
-      playersPerTeam: Joi.number().optional(),
-      coachesPerTeam: Joi.number().optional(),
       cashprize: Joi.number().optional(),
       cashprizeDetails: Joi.string().optional(),
       displayCashprize: Joi.boolean().optional(),
@@ -24,7 +22,6 @@ export default [
       casters: Joi.array().items(Joi.string()).optional(),
       displayCasters: Joi.boolean().optional(),
       display: Joi.boolean().optional(),
-      position: Joi.number().optional(),
     }),
   ),
 
@@ -32,15 +29,14 @@ export default [
   async (request: Request, response: Response, next: NextFunction) => {
     try {
       const allTournaments = await fetchTournaments();
-      if (!allTournaments.some((tournament) => tournament.id === request.params.tournamentId)) {
+      const tournament = allTournaments.find((t) => t.id === request.params.tournamentId);
+      if (!tournament) {
         return notFound(response, Error.NotFound);
       }
 
       if (
         request.body.name &&
-        allTournaments.some(
-          (tournament) => tournament.name === request.body.name && tournament.id !== request.params.tournamentId,
-        )
+        allTournaments.some((t) => t.name === request.body.name && t.id !== request.params.tournamentId)
       ) {
         return conflict(response, Error.TournamentNameAlreadyExists);
       }
@@ -53,6 +49,13 @@ export default [
         }
       }
       request.body.casters = undefined;
+
+      if (
+        request.body.maxPlayers !== undefined &&
+        tournament.placesLeft < (tournament.maxPlayers - request.body.maxPlayers) / tournament.playersPerTeam
+      ) {
+        return forbidden(response, Error.TooMuchLockedTeams);
+      }
 
       const result = await updateTournament(request.params.tournamentId as string, request.body);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -317,6 +317,7 @@ export const enum Error {
   NotYourItem = "Cet item n'est pas le tiens",
   AlreadyHaveComputer = 'Tu as déjà un ordinateur stocké',
   AlreadyPickedUp = "L'objet a déjà été récupéré",
+  TooMuchLockedTeams = "Il y a plus d'équipes inscrites que le nombre d'équipes maximal souhaité",
 
   // 404
   // The server can't find the requested resource

--- a/tests/admin/tournaments/updateTournament.test.ts
+++ b/tests/admin/tournaments/updateTournament.test.ts
@@ -157,10 +157,10 @@ describe('PATCH /admin/tournaments/{tournamentId}', () => {
     await database.tournament.update({ where: { id: tournament.id }, data: { maxPlayers: 5 } });
     // Decrease it once (check that nothing goes wrong if the tournament will still have places left after the operation)
     // And then twice (check that nothing goes wrong if the tournament is full after the operation)
-    for (const i of [4, 3]) {
+    for (const maxPlayers of [4, 3]) {
       await request(app)
         .patch(`/admin/tournaments/${tournament.id}`)
-        .send({ maxPlayers: i })
+        .send({ maxPlayers })
         .set('Authorization', `Bearer ${adminToken}`)
         .expect(200);
 

--- a/tests/admin/tournaments/updateTournament.test.ts
+++ b/tests/admin/tournaments/updateTournament.test.ts
@@ -4,21 +4,21 @@ import app from '../../../src/app';
 import { sandbox } from '../../setup';
 import * as tournamentOperations from '../../../src/operations/tournament';
 import database from '../../../src/services/database';
-import { Error, Permission, Tournament, User, UserType } from '../../../src/types';
-import { createFakeTournament, createFakeUser } from '../../utils';
+import { Error, Permission, Team, Tournament, User, UserType } from '../../../src/types';
+import { createFakeTeam, createFakeTournament, createFakeUser } from '../../utils';
 import { generateToken } from '../../../src/utils/users';
+import { lockTeam } from '../../../src/operations/team';
 
 describe('PATCH /admin/tournaments/{tournamentId}', () => {
   let nonAdminUser: User;
   let admin: User;
   let adminToken: string;
   let tournament: Tournament;
+  const teams: Team[] = [];
 
   const validBody = {
     name: 'anothertestname',
-    maxPlayers: 100,
-    playersPerTeam: 5,
-    coachesPerTeam: 2,
+    maxPlayers: 3,
     cashprize: 100,
     cashprizeDetails: 'test',
     displayCashprize: true,
@@ -27,10 +27,12 @@ describe('PATCH /admin/tournaments/{tournamentId}', () => {
     casters: ['test'],
     displayCasters: true,
     display: true,
-    position: 150,
   };
 
   after(async () => {
+    await database.cart.deleteMany();
+    await database.cartItem.deleteMany();
+    await database.team.deleteMany();
     await database.user.deleteMany();
     await database.tournament.delete({ where: { id: tournament.id } });
   });
@@ -47,6 +49,19 @@ describe('PATCH /admin/tournaments/{tournamentId}', () => {
       coachesPerTeam: 1,
       maxTeams: 1,
     });
+
+    // Create 4 teams : 1 will be locked, 3 in the queue, of which 2 will be locked after tournament modifications
+    for (let index = 0; index < 4; index++) {
+      const team = await createFakeTeam({ members: 1, tournament: tournament.id, paid: true, name: `test-${index}` });
+      teams.push(await lockTeam(team.id));
+    }
+    // Verify lock has been done correctly
+    expect(teams[0].lockedAt).to.not.be.null;
+    expect(teams[0].enteredQueueAt).to.be.null;
+    for (let index = 1; index < 4; index++) {
+      expect(teams[index].lockedAt).to.be.null;
+      expect(teams[index].enteredQueueAt).to.not.be.null;
+    }
   });
 
   it('should error as the user is not authenticated', () =>
@@ -101,8 +116,6 @@ describe('PATCH /admin/tournaments/{tournamentId}', () => {
 
     expect(tournamentDatabase.name).to.equal(validBody.name);
     expect(tournamentDatabase.maxPlayers).to.equal(validBody.maxPlayers);
-    expect(tournamentDatabase.playersPerTeam).to.equal(validBody.playersPerTeam);
-    expect(tournamentDatabase.coachesPerTeam).to.equal(validBody.coachesPerTeam);
     expect(tournamentDatabase.cashprize).to.equal(validBody.cashprize);
     expect(tournamentDatabase.cashprizeDetails).to.equal(validBody.cashprizeDetails);
     expect(tournamentDatabase.displayCashprize).to.equal(validBody.displayCashprize);
@@ -112,6 +125,40 @@ describe('PATCH /admin/tournaments/{tournamentId}', () => {
     expect(tournamentDatabase.casters[0].name).to.be.equal(validBody.casters[0]);
     expect(tournamentDatabase.displayCasters).to.equal(validBody.displayCasters);
     expect(tournamentDatabase.display).to.equal(validBody.display);
-    expect(tournamentDatabase.position).to.equal(150);
+
+    // Check what happened with queued teams
+    for (let indexDatabase = 0; indexDatabase < 4; indexDatabase++) {
+      const indexTeam = teams.findIndex((team) => team.id === tournamentDatabase.teams[indexDatabase].id);
+      if (indexTeam === 0) {
+        // Team should not have changed
+        expect(tournamentDatabase.teams[indexDatabase].lockedAt?.toISOString()).to.be.equal(
+          teams[indexTeam].lockedAt?.toISOString(),
+        );
+        expect(tournamentDatabase.teams[indexDatabase].enteredQueueAt).to.be.null;
+      } else if (indexTeam === 3) {
+        // Team should still be in queue
+        expect(tournamentDatabase.teams[indexDatabase].lockedAt).to.be.null;
+        expect(tournamentDatabase.teams[indexDatabase].enteredQueueAt?.toISOString()).to.be.equal(
+          teams[indexTeam].enteredQueueAt?.toISOString(),
+        );
+      } else {
+        // Teams 1 et 2 should be locked
+        expect(tournamentDatabase.teams[indexDatabase].lockedAt?.toISOString()).to.be.equal(
+          teams[indexTeam].enteredQueueAt?.toISOString(),
+        );
+        expect(tournamentDatabase.teams[indexDatabase].enteredQueueAt).to.be.null;
+      }
+    }
+  });
+
+  it('should throw an error as their are too many locked teams to reduce the maximum number of teams', async () => {
+    await request(app)
+      .patch(`/admin/tournaments/${tournament.id}`)
+      .send({ maxPlayers: 2 })
+      .set('Authorization', `Bearer ${adminToken}`)
+      .expect(403, { error: Error.TooMuchLockedTeams });
+
+    const tournamentDatabase = await tournamentOperations.fetchTournament(tournament.id);
+    expect(tournamentDatabase.maxPlayers).to.equal(validBody.maxPlayers);
   });
 });

--- a/tests/middlewares.test.ts
+++ b/tests/middlewares.test.ts
@@ -19,7 +19,7 @@ describe('Test middlewares', () => {
       delete require.cache[require.resolve('../src/utils/env')];
       process.env.NODE_ENV = 'development';
       const { default: nonTestApp } = await import('../src/app');
-      await Promise.all([...Array(12).keys()].map(async () => request(nonTestApp).get('/').expect(200)));
+      await Promise.all([...new Array(12).keys()].map(() => request(nonTestApp).get('/').expect(200)));
       await request(nonTestApp).get('/').expect(429, 'Too Many Requests');
       // ANNNNNDDDD... for some reason you don't need to delete the new cache :)
       process.env.NODE_ENV = 'test';

--- a/tests/middlewares.test.ts
+++ b/tests/middlewares.test.ts
@@ -19,7 +19,7 @@ describe('Test middlewares', () => {
       delete require.cache[require.resolve('../src/utils/env')];
       process.env.NODE_ENV = 'development';
       const { default: nonTestApp } = await import('../src/app');
-      await Promise.all([...new Array(12).keys()].map(() => request(nonTestApp).get('/').expect(200)));
+      await Promise.all(Array.from({ length: 12 }).map(() => request(nonTestApp).get('/').expect(200)));
       await request(nonTestApp).get('/').expect(429, 'Too Many Requests');
       // ANNNNNDDDD... for some reason you don't need to delete the new cache :)
       process.env.NODE_ENV = 'test';

--- a/tests/middlewares.test.ts
+++ b/tests/middlewares.test.ts
@@ -13,6 +13,19 @@ describe('Test middlewares', () => {
     await database.user.deleteMany();
   });
 
+  describe('Test rate limiter', () => {
+    it('should return a too many requests error', async () => {
+      delete require.cache[require.resolve('../src/app')];
+      delete require.cache[require.resolve('../src/utils/env')];
+      process.env.NODE_ENV = 'development';
+      const { default: nonTestApp } = await import('../src/app');
+      await Promise.all([...Array(12).keys()].map(async () => request(nonTestApp).get('/').expect(200)));
+      await request(nonTestApp).get('/').expect(429, 'Too Many Requests');
+      // ANNNNNDDDD... for some reason you don't need to delete the new cache :)
+      process.env.NODE_ENV = 'test';
+    });
+  });
+
   describe('Test general middleware', () => {
     it('should return a not found error', () =>
       request(app).get('/randomRoute').expect(404, { error: Error.RouteNotFound }));


### PR DESCRIPTION
# Small problems of route PATCH /admin/tournaments/:id

## Changes

* when we increased the size of a tournament, teams in the queue would not be locked
* you could modify the fields playersPerTeam, coachesPerTeam and position
* an error is thrown if you try to set a maximum of teams that is smaller than the number of locked teams

## Breaking changes

route PATCH /admin/tournaments/:id changed
